### PR TITLE
Fixed NullReferenceException, if schema.Properties is null

### DIFF
--- a/src/MicroElements.Swashbuckle.FluentValidation/FluentValidationRules.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/FluentValidationRules.cs
@@ -69,7 +69,7 @@ namespace MicroElements.Swashbuckle.FluentValidation
 
             var validatorDescriptor = validator.CreateDescriptor();
 
-            foreach (var key in schema.Properties.Keys)
+            foreach (var key in schema?.Properties?.Keys ?? Array.Empty<string>())
             {
                 foreach (var propertyValidator in validatorDescriptor.GetValidatorsForMemberIgnoreCase(key).NotNull())
                 {


### PR DESCRIPTION
I have a project, where the some schema's have Properties == null. This pull request fixes the issue :)