### PR TITLE
Ignore conditional validators (when/unless). 

### DIFF
--- a/samples/SampleWebApi/SampleWebApi.csproj
+++ b/samples/SampleWebApi/SampleWebApi.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
 
-    <PackageReference Include="FluentValidation.AspNetCore" Version="7.5.2" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="8.1.3" />
 
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.0" />
 

--- a/samples/SampleWebApi/Validators/CustomerValidator.cs
+++ b/samples/SampleWebApi/Validators/CustomerValidator.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation;
+﻿using System.Threading.Tasks;
+using FluentValidation;
 using SampleWebApi.Contracts;
 
 namespace SampleWebApi.Validators
@@ -7,8 +8,26 @@ namespace SampleWebApi.Validators
     {
         public CustomerValidator()
         {
-            RuleFor(customer => customer.Surname).NotEmpty();
-            RuleFor(customer => customer.Forename).NotEmpty().WithMessage("Please specify a first name");
+            When(customer => customer.Id == 1, () =>
+            {
+                RuleFor(customer => customer.Discount)
+                    .NotEmpty()
+                    .WithMessage("This WILL NOT be in the OpenAPI  spec.");
+            });
+
+            RuleFor(customer => customer.Discount)
+                .ExclusiveBetween(4, 5)
+                .WithMessage("This WILL be in the OpenAPI spec.");
+            RuleFor(customer => customer.Discount)
+                .NotEmpty()
+                .WhenAsync((customer, token) => Task.FromResult(customer.Id == 1))
+                .WithMessage("This WILL NOT be in the OpenAPI spec.");
+
+            RuleFor(customer => customer.Surname)
+                .NotEmpty();
+            RuleFor(customer => customer.Forename)
+                .NotEmpty()
+                .WithMessage("Please specify a first name");
 
             Include(new CustomerAddressValidator());
         }
@@ -18,7 +37,20 @@ namespace SampleWebApi.Validators
     {
         public CustomerAddressValidator()
         {
-            RuleFor(customer => customer.Address).Length(20, 250);
+            UnlessAsync((customer, token) => Task.FromResult(customer.Surname == "Test"), () =>
+            {
+                RuleFor(customer => customer.Discount)
+                    .NotEmpty()
+                    .WithMessage("This WILL NOT be in the OpenAPI spec.");
+            });
+
+            RuleFor(customer => customer.Discount)
+                .NotEmpty()
+                .Unless(customer => customer.Surname == "Test")
+                .WithMessage("This WILL NOT be in the OpenAPI spec.");
+
+            RuleFor(customer => customer.Address)
+                .Length(20, 250);
         }
     }
 }

--- a/src/MicroElements.Swashbuckle.FluentValidation/Extensions.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/Extensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
+using FluentValidation.Internal;
 using FluentValidation.Validators;
 using JetBrains.Annotations;
 
@@ -74,13 +75,16 @@ namespace MicroElements.Swashbuckle.FluentValidation
         /// <summary>
         /// Returns validators by property name ignoring name case.
         /// </summary>
-        /// <param name="validatorDescriptor">Validation metadata.</param>
+        /// <param name="validator">Validator</param>
         /// <param name="name">Property name.</param>
         /// <returns>enumeration or null.</returns>
-        [CanBeNull]
-        public static IEnumerable<IPropertyValidator> GetValidatorsForMemberIgnoreCase(this IValidatorDescriptor validatorDescriptor, string name)
+        public static IEnumerable<IPropertyValidator> GetValidatorsForMemberIgnoreCase(this IValidator validator, string name)
         {
-            return validatorDescriptor.GetMembersWithValidators().FirstOrDefault(grouping => grouping.Key.Equals(name, StringComparison.InvariantCultureIgnoreCase));
+            return (validator as IEnumerable<IValidationRule>)
+                .NotNull()
+                .OfType<PropertyRule>()
+                .Where(propertyRule => propertyRule.Condition == null && propertyRule.AsyncCondition == null && propertyRule.PropertyName?.Equals(name, StringComparison.InvariantCultureIgnoreCase) == true)
+                .SelectMany(propertyRule => propertyRule.Validators);
         }
     }
 }

--- a/src/MicroElements.Swashbuckle.FluentValidation/FluentValidationOperationFilter.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/FluentValidationOperationFilter.cs
@@ -72,9 +72,8 @@ namespace MicroElements.Swashbuckle.FluentValidation
                     if (validator == null)
                         continue;
 
-                    var descriptor = validator.CreateDescriptor();
                     var key = modelMetadata.PropertyName;
-                    var validatorsForMember = descriptor.GetValidatorsForMemberIgnoreCase(key).NotNull();
+                    var validatorsForMember = validator.GetValidatorsForMemberIgnoreCase(key);
 
                     Schema schema = null;
                     foreach (var propertyValidator in validatorsForMember)

--- a/src/MicroElements.Swashbuckle.FluentValidation/MicroElements.Swashbuckle.FluentValidation.csproj
+++ b/src/MicroElements.Swashbuckle.FluentValidation/MicroElements.Swashbuckle.FluentValidation.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="7.2.0" />
+    <PackageReference Include="FluentValidation" Version="8.1.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="[4.0.1, 5.0.0)" />
   </ItemGroup>
 


### PR DESCRIPTION
FluentValidation 8.1.2 changed how conditions are handled when rules are wrapped with When or Unless. This breaks the swagger since these rules are now added. See https://github.com/JeremySkinner/FluentValidation/commit/d2b3b9cfa161fd02e1259d60becfb32d628ea30b for what changed. Rules wrapped with When or Unless are no longer created as a DelegatingValidator.

Updated FluentValidation dependency to 8.1.3 to enable this check. 8.1.3 added the Condition and AsyncCondition properties. I do not like the bump of the FluentValidation version but I could not find a way to accomplish this without it.