### PR TITLE
Add scoped validator factory and updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,9 @@ public static IWebHost BuildWebHost(string[] args) =>
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
+    // ServiceProviderScopedValidatorFactory requires access to HttpContext
+    services.AddHttpContextAccessor();
+
     services
         .AddMvc()
         // Adds fluent validators to Asp.net
@@ -234,10 +237,9 @@ public void ConfigureServices(IServiceCollection services)
             // Optionally set validator factory if you have problems with scope resolve inside validators.
             c.ValidatorFactoryType = typeof(ServiceProviderScopedValidatorFactory);
         });
-
 ```
 
-See source of ScopedServiceProviderValidatorFactory: https://github.com/micro-elements/MicroElements.Swashbuckle.FluentValidation/tree/master/src/SampleWebApi
+See source of ScopedServiceProviderValidatorFactory: https://github.com/micro-elements/MicroElements.Swashbuckle.FluentValidation/tree/master/src/MicroElements.Swashbuckle.FluentValidation/ServiceProviderScopedValidatorFactory.cs
 
 ## Problem: I cant use several validators of one type
 

--- a/src/MicroElements.Swashbuckle.FluentValidation/ServiceProviderScopedValidatorFactory.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/ServiceProviderScopedValidatorFactory.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using FluentValidation;
+using Microsoft.AspNetCore.Http;
+
+namespace MicroElements.Swashbuckle.FluentValidation
+{
+    /// <summary>
+    /// Allows for the creation of validators that have dependencies
+    /// on scoped services
+    /// </summary>
+    public class ServiceProviderScopedValidatorFactory : ValidatorFactoryBase
+    {
+        private readonly HttpContext HttpContext;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceProviderScopedValidatorFactory"/> class.
+        /// </summary>
+        /// <param name="httpContextAccessor">Access to the current HttpContext</param>
+        public ServiceProviderScopedValidatorFactory(IHttpContextAccessor httpContextAccessor)
+        {
+            HttpContext = httpContextAccessor.HttpContext;
+        }
+
+        /// <inheritdoc/>
+        public override IValidator CreateInstance(Type validatorType)
+        {
+            return HttpContext.RequestServices.GetService(validatorType) as IValidator;
+        }
+    }
+}


### PR DESCRIPTION
As mentioned in issue #23 I've added in a new class that can be utilised by projects with scoped dependencies in validators to replace the standard FluentValidation ValidatorFactory. I've also updated the documentation with its usage.