### PR TITLE
Fixes for invalid documentation on validation rules containing a cond…

### DIFF
--- a/samples/SampleWebApi/SampleWebApi.csproj
+++ b/samples/SampleWebApi/SampleWebApi.csproj
@@ -1,17 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
 
-    <PackageReference Include="FluentValidation.AspNetCore" Version="8.1.3" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="8.3.0" />
 
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.7" />
 
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />
+
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.6" />
     <!--PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="0.4.0" /-->
     <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
   </ItemGroup>

--- a/src/MicroElements.Swashbuckle.FluentValidation/Extensions.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/Extensions.cs
@@ -86,5 +86,15 @@ namespace MicroElements.Swashbuckle.FluentValidation
                 .Where(propertyRule => propertyRule.Condition == null && propertyRule.AsyncCondition == null && propertyRule.PropertyName?.Equals(name, StringComparison.InvariantCultureIgnoreCase) == true)
                 .SelectMany(propertyRule => propertyRule.Validators);
         }
+
+        /// <summary>
+        /// Returns a <see cref="bool"/> indicating if the <paramref name="propertyValidator"/> is conditional.
+        /// </summary>
+        /// <param name="propertyValidator"></param>
+        /// <returns></returns>
+        internal static bool HasNoCondition(this IPropertyValidator propertyValidator)
+        {
+            return propertyValidator?.Options?.Condition == null && propertyValidator?.Options?.AsyncCondition == null;
+        }
     }
 }

--- a/src/MicroElements.Swashbuckle.FluentValidation/FluentValidationRules.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/FluentValidationRules.cs
@@ -58,7 +58,7 @@ namespace MicroElements.Swashbuckle.FluentValidation
 
             IValidator validator = null;
             try
-            {       
+            {
                 validator = _validatorFactory.GetValidator(context.SystemType);
             }
             catch (Exception e)
@@ -141,7 +141,7 @@ namespace MicroElements.Swashbuckle.FluentValidation
             {
                 new FluentValidationRule("Required")
                 {
-                    Matches = propertyValidator => propertyValidator is INotNullValidator || propertyValidator is INotEmptyValidator,
+                    Matches = propertyValidator => (propertyValidator is INotNullValidator || propertyValidator is INotEmptyValidator) && propertyValidator.HasNoCondition(),
                     Apply = context =>
                     {
                         if (context.Schema.Required == null)
@@ -152,7 +152,7 @@ namespace MicroElements.Swashbuckle.FluentValidation
                 },
                 new FluentValidationRule("NotEmpty")
                 {
-                    Matches = propertyValidator => propertyValidator is INotEmptyValidator,
+                    Matches = propertyValidator => propertyValidator is INotEmptyValidator && propertyValidator.HasNoCondition(),
                     Apply = context =>
                     {
                         context.Schema.Properties[context.PropertyKey].MinLength = 1;
@@ -160,7 +160,7 @@ namespace MicroElements.Swashbuckle.FluentValidation
                 },
                 new FluentValidationRule("Length")
                 {
-                    Matches = propertyValidator => propertyValidator is ILengthValidator,
+                    Matches = propertyValidator => propertyValidator is ILengthValidator && propertyValidator.HasNoCondition(),
                     Apply = context =>
                     {
                         var lengthValidator = (ILengthValidator)context.PropertyValidator;
@@ -176,7 +176,7 @@ namespace MicroElements.Swashbuckle.FluentValidation
                 },
                 new FluentValidationRule("Pattern")
                 {
-                    Matches = propertyValidator => propertyValidator is IRegularExpressionValidator,
+                    Matches = propertyValidator => propertyValidator is IRegularExpressionValidator && propertyValidator.HasNoCondition(),
                     Apply = context =>
                     {
                         var regularExpressionValidator = (IRegularExpressionValidator)context.PropertyValidator;
@@ -185,7 +185,7 @@ namespace MicroElements.Swashbuckle.FluentValidation
                 },
                 new FluentValidationRule("Comparison")
                 {
-                    Matches = propertyValidator => propertyValidator is IComparisonValidator,
+                    Matches = propertyValidator => propertyValidator is IComparisonValidator && propertyValidator.HasNoCondition(),
                     Apply = context =>
                     {
                         var comparisonValidator = (IComparisonValidator)context.PropertyValidator;
@@ -217,7 +217,7 @@ namespace MicroElements.Swashbuckle.FluentValidation
                 },
                 new FluentValidationRule("Between")
                 {
-                    Matches = propertyValidator => propertyValidator is IBetweenValidator,
+                    Matches = propertyValidator => propertyValidator is IBetweenValidator && propertyValidator.HasNoCondition(),
                     Apply = context =>
                     {
                         var betweenValidator = (IBetweenValidator)context.PropertyValidator;

--- a/src/MicroElements.Swashbuckle.FluentValidation/MicroElements.Swashbuckle.FluentValidation.csproj
+++ b/src/MicroElements.Swashbuckle.FluentValidation/MicroElements.Swashbuckle.FluentValidation.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="8.1.3" />
+    <PackageReference Include="FluentValidation" Version="8.3.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="[4.0.1, 5.0.0)" />
   </ItemGroup>
 

--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/MicroElements.Swashbuckle.FluentValidation.Tests.csproj
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/MicroElements.Swashbuckle.FluentValidation.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
fixes #38  

The inner workings of conditionals has been changed in FluentValidation 8.3. 
Before the 8.3 version the FluentValidation validators that contained a conditional would be of type `DelegatingValidator`, and because the type `DelegatingValidator ` was not checked anywhere in the `FluentValidationRules` class in the `MicroElements.Swashbuckle.FluentValidation` package, no documentation for these conditionals were added. 

FluentValidation 8.3 deprecated the `DelegatingValidator` and used a different mechanism of storing the conditions. The validators that contains a condition will be the normal type (e.g. `NotNullValidator`) and now contains the properties `Condition` and `AsyncCondition`.