### PR TITLE
Add support for customer IContractResolver / naming conventions

### DIFF
--- a/MicroElements.Swashbuckle.FluentValidation.sln
+++ b/MicroElements.Swashbuckle.FluentValidation.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2027
@@ -15,7 +15,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		version.props = version.props
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MicroElements.Swashbuckle.FluentValidation.Tests", "test\MicroElements.Swashbuckle.FluentValidation.Tests\MicroElements.Swashbuckle.FluentValidation.Tests.csproj", "{AAA88B0E-AA41-402F-B41B-AE95DBBD746C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MicroElements.Swashbuckle.FluentValidation.Tests", "test\MicroElements.Swashbuckle.FluentValidation.Tests\MicroElements.Swashbuckle.FluentValidation.Tests.csproj", "{AAA88B0E-AA41-402F-B41B-AE95DBBD746C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleAlternativeNamingStrategy", "samples\SampleAlternativeContractResolver\SampleAlternativeNamingStrategy.csproj", "{61E2CBC8-C065-45F2-9295-DDE53FD43DCB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -35,6 +37,10 @@ Global
 		{AAA88B0E-AA41-402F-B41B-AE95DBBD746C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AAA88B0E-AA41-402F-B41B-AE95DBBD746C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AAA88B0E-AA41-402F-B41B-AE95DBBD746C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{61E2CBC8-C065-45F2-9295-DDE53FD43DCB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{61E2CBC8-C065-45F2-9295-DDE53FD43DCB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{61E2CBC8-C065-45F2-9295-DDE53FD43DCB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{61E2CBC8-C065-45F2-9295-DDE53FD43DCB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/SampleAlternativeContractResolver/Contracts/BasicGetRequest.cs
+++ b/samples/SampleAlternativeContractResolver/Contracts/BasicGetRequest.cs
@@ -1,0 +1,59 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using SampleAlternativeNamingStrategy.Validators;
+
+namespace SampleAlternativeNamingStrategy.Contracts
+{
+    /// <summary>
+    /// Sample GET request with headers mapped from nested class.
+    /// </summary>
+    public class BasicGetRequest
+    {
+        public StandardHeaders StandardHeaders { get; set; }
+
+        [FromHeader]
+        public string ValueFromHeader { get; set; }
+
+        [FromQuery]
+        public string ValueFromQuery { get; set; }
+    }
+
+    /// <summary>
+    /// Standard headers.
+    /// </summary>
+    public class StandardHeaders
+    {
+        [FromHeader(Name = "TransactionId")]
+        public string TransactionId { get; set; }
+
+        [FromHeader(Name = "RequestId")]
+        public string RequestId { get; set; }
+    }
+
+    public class RequestWithAnnotations
+    {
+        public HeadersWithAnnotations Headers { get; set; }
+
+        [Required]
+        [FromHeader]
+        [MaxLength(10)]
+        public string ValueFromHeader { get; set; }
+
+        [Required]
+        [FromQuery]
+        public string ValueFromQuery { get; set; }
+    }
+
+    public class HeadersWithAnnotations
+    {
+        [MinLength(5)]
+        [Required]
+        [FromHeader(Name = "TransactionId")]
+        public string TransactionId { get; set; }
+
+        [RegularExpression(Constants.GuidRegex)]
+        [Required]
+        [FromHeader(Name = "RequestId")]
+        public string RequestId { get; set; }
+    }
+}

--- a/samples/SampleAlternativeContractResolver/Contracts/Customer.cs
+++ b/samples/SampleAlternativeContractResolver/Contracts/Customer.cs
@@ -1,0 +1,11 @@
+﻿namespace SampleAlternativeNamingStrategy.Contracts
+{
+    public class Customer
+    {
+        public int Id { get; set; }
+        public string Surname { get; set; }
+        public string Forename { get; set; }
+        public decimal Discount { get; set; }
+        public string Address { get; set; }
+    }
+}

--- a/samples/SampleAlternativeContractResolver/Contracts/Dependencies.cs
+++ b/samples/SampleAlternativeContractResolver/Contracts/Dependencies.cs
@@ -1,0 +1,50 @@
+﻿using FluentValidation;
+
+namespace SampleAlternativeNamingStrategy.Contracts
+{
+    // https://github.com/micro-elements/MicroElements.Swashbuckle.FluentValidation/issues/5
+    public class ObjectA
+    {
+        public string Key { get; set; }
+        public ObjectB ObjectB { get; set; }
+    }
+
+    public class ObjectB
+    {
+        public string Key { get; set; }
+        public ObjectC ObjectC { get; set; }
+    }
+
+    public class ObjectC
+    {
+        public string Key { get; set; }
+        public ObjectA ObjectA { get; set; }
+    }
+
+    public class ObjectAValidator : AbstractValidator<ObjectA>
+    {
+        public ObjectAValidator()
+        {
+            RuleFor(sample => sample.Key).NotNull();
+            RuleFor(sample => sample.ObjectB).NotNull();
+        }
+    }
+
+    public class ObjectBValidator : AbstractValidator<ObjectB>
+    {
+        public ObjectBValidator()
+        {
+            RuleFor(sample => sample.Key).NotNull();
+            RuleFor(sample => sample.ObjectC).NotNull();
+        }
+    }
+
+    public class ObjectCValidator : AbstractValidator<ObjectC>
+    {
+        public ObjectCValidator()
+        {
+            RuleFor(sample => sample.Key).NotNull();
+            RuleFor(sample => sample.ObjectA).NotNull();
+        }
+    }
+}

--- a/samples/SampleAlternativeContractResolver/Contracts/Sample.cs
+++ b/samples/SampleAlternativeContractResolver/Contracts/Sample.cs
@@ -1,0 +1,102 @@
+﻿using System.ComponentModel.DataAnnotations;
+using FluentValidation;
+
+namespace SampleAlternativeNamingStrategy.Contracts
+{
+    public class Sample
+    {
+        public string PropertyWithNoRules { get; set; }
+
+        public string NotNull { get; set; }
+        public string NotEmpty { get; set; }
+        public string EmailAddress { get; set; }
+        public string RegexField { get; set; }
+
+        public int ValueInRange { get; set; }
+        public int ValueInRangeExclusive { get; set; }
+
+        public float ValueInRangeFloat { get; set; }
+        public double ValueInRangeDouble { get; set; }
+        public decimal DecimalValue { get; set; }
+
+        public string NotEmptyWithMaxLength { get; set; }
+
+        // ReSharper disable once InconsistentNaming
+        // https://github.com/micro-elements/MicroElements.Swashbuckle.FluentValidation/issues/10
+        public string javaStyleProperty { get; set; }
+    }
+
+    public class SampleValidator : AbstractValidator<Sample>
+    {
+        public SampleValidator()
+        {
+            RuleFor(sample => sample.NotNull).NotNull();
+            RuleFor(sample => sample.NotEmpty).NotEmpty();
+            RuleFor(sample => sample.EmailAddress).EmailAddress();
+            RuleFor(sample => sample.RegexField).Matches(@"(\d{4})-(\d{2})-(\d{2})");
+
+            RuleFor(sample => sample.ValueInRange).GreaterThanOrEqualTo(5).LessThanOrEqualTo(10);
+            RuleFor(sample => sample.ValueInRangeExclusive).GreaterThan(5).LessThan(10);
+
+            RuleFor(sample => sample.ValueInRangeFloat).InclusiveBetween(5.1f, 10.2f);
+            RuleFor(sample => sample.ValueInRangeDouble).ExclusiveBetween(5.1, 10.2);
+            RuleFor(sample => sample.DecimalValue).InclusiveBetween(1.333m, 200.333m);
+
+            RuleFor(sample => sample.javaStyleProperty).MaximumLength(6);
+
+            RuleFor(sample => sample.NotEmptyWithMaxLength).NotEmpty().MaximumLength(50);
+        }
+    }
+
+    public class SampleWithDataAnnotations
+    {
+        public string PropertyWithNoRules { get; set; }
+
+        [Required]
+        public string NotNull { get; set; }
+
+        [MinLength(1)]
+        public string NotEmpty { get; set; }
+
+        [EmailAddress]
+        public string EmailAddress { get; set; }
+
+        [RegularExpression(@"(\d{4})-(\d{2})-(\d{2})")]
+        public string RegexField { get; set; }
+
+        [Range(5, 10)]
+        public int ValueInRange { get; set; }
+
+        [Range(5.1f, 10.2f)]
+        public float ValueInRangeFloat { get; set; }
+
+        [Range(5.1, 10.2)]
+        public double ValueInRangeDouble { get; set; }
+
+        [Range(1.333, 200.333)]
+        public decimal DecimalValue { get; set; }
+
+        [MaxLength(6)]
+        public string javaStyleProperty { get; set; }
+
+        [MinLength(1)]
+        [MaxLength(50)]
+        public string NotEmptyWithMaxLength { get; set; }
+    }
+
+    // https://github.com/micro-elements/MicroElements.Swashbuckle.FluentValidation/issues/6
+    public class SampleWithNoRequired
+    {
+        public string PropertyWithNoRules { get; set; }
+
+        public int ValueInRange { get; set; }
+    }
+
+    public class SampleWithNoRequiredValidator : AbstractValidator<SampleWithNoRequired>
+    {
+        public SampleWithNoRequiredValidator()
+        {
+            RuleFor(sample => sample.ValueInRange).GreaterThanOrEqualTo(5).LessThanOrEqualTo(10);
+        }
+    }
+}

--- a/samples/SampleAlternativeContractResolver/Controllers/BasicController.cs
+++ b/samples/SampleAlternativeContractResolver/Controllers/BasicController.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+using SampleAlternativeNamingStrategy.Contracts;
+
+namespace SampleAlternativeNamingStrategy.Controllers
+{
+    [Route("api/[controller]")]
+    public class BasicController : Controller
+    {
+        [HttpGet("[action]")]
+        [ProducesResponseType(typeof(IEnumerable<Customer>), 200)]
+        public IActionResult GetWithFluentValidation(BasicGetRequest req)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+            
+            var customers = new[] { new Customer
+            {
+                Surname = "Bill",
+                Forename = "Gates"
+            } };
+
+            return Ok(customers);
+        }
+
+        [HttpGet("[action]")]
+        [ProducesResponseType(typeof(IEnumerable<Customer>), 200)]
+        public IActionResult GetWithDataAnnotation(RequestWithAnnotations req)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var customers = new[] { new Customer
+            {
+                Surname = "Bill",
+                Forename = "Gates"
+            } };
+
+            return Ok(customers);
+        }
+    }
+}

--- a/samples/SampleAlternativeContractResolver/Controllers/BloggingController.cs
+++ b/samples/SampleAlternativeContractResolver/Controllers/BloggingController.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using SampleAlternativeNamingStrategy.DbModels;
+
+namespace SampleAlternativeNamingStrategy.Controllers
+{
+    [Route("api/[controller]")]
+    public class BloggingController : Controller
+    {
+        private readonly BloggingDbContext _dbContext;
+
+        public BloggingController(BloggingDbContext dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        [HttpPost("[action]")]
+        public IActionResult AddBlog([FromBody] Blog blog)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            _dbContext.Blogs.Add(blog);
+            _dbContext.SaveChanges();
+            return Ok("Blog added");
+        }
+
+        [HttpGet("[action]")]
+        public IEnumerable<Blog> GetBlogs()
+        {
+            return _dbContext.Blogs.Select(blog => blog);
+        }
+    }
+}

--- a/samples/SampleAlternativeContractResolver/Controllers/SampleApiController.cs
+++ b/samples/SampleAlternativeContractResolver/Controllers/SampleApiController.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+using SampleAlternativeNamingStrategy.Contracts;
+
+namespace SampleAlternativeNamingStrategy.Controllers
+{
+    [Route("api/[controller]")]
+    public class SampleApiController : Controller
+    {
+        [HttpGet]
+        public IEnumerable<Customer> Get()
+        {
+            return new[] { new Customer
+            {
+                Surname = "Bill",
+                Forename = "Gates"
+            } };
+        }
+
+        [HttpPost("[action]")]
+        public IActionResult AddCustomer([FromBody] Customer customer)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            return Ok();
+        }
+
+        [HttpPost("[action]")]
+        public IActionResult AddSample([FromBody] Sample sample)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            return Ok();
+        }
+
+        [HttpPost("[action]")]
+        public IActionResult AddSampleWithDataAnnotations([FromBody] SampleWithDataAnnotations sample)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            return Ok();
+        }
+
+        [HttpPost("[action]")]
+        public IActionResult AddObjectA([FromBody] ObjectA objectA)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            return Ok();
+        }
+
+        [HttpPost("[action]")]
+        public IActionResult AddSampleWithNoRequired([FromBody] SampleWithNoRequired customer)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            return Ok();
+        }
+    }
+}

--- a/samples/SampleAlternativeContractResolver/DbModels/BloggingDbContext.cs
+++ b/samples/SampleAlternativeContractResolver/DbModels/BloggingDbContext.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+
+namespace SampleAlternativeNamingStrategy.DbModels
+{
+    /// <summary>
+    /// BloggingDbContext.
+    /// </summary>
+    public class BloggingDbContext : DbContext
+    {
+        public BloggingDbContext(DbContextOptions<BloggingDbContext> options)
+            : base(options)
+        { }
+
+        public DbSet<Blog> Blogs { get; set; }
+        public DbSet<Post> Posts { get; set; }
+        public DbSet<ValidationMetadata> Metadata { get; set; }
+    }
+
+    /// <summary>
+    /// The blog.
+    /// </summary>
+    public class Blog
+    {
+        /// <summary>
+        /// Id.
+        /// </summary>
+        public int BlogId { get; set; }
+
+        /// <summary>
+        /// The url of blog.
+        /// </summary>
+        public string Url { get; set; }
+
+        /// <summary>
+        /// Blog Author.
+        /// </summary>
+        public string Author { get; set; }
+
+        /// <summary>
+        /// Blog posts list.
+        /// </summary>
+        public List<Post> Posts { get; set; }
+    }
+
+    /// <summary>
+    /// Blog post.
+    /// </summary>
+    public class Post
+    {
+        public int PostId { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+
+        public int BlogId { get; set; }
+        public Blog Blog { get; set; }
+    }
+
+    /// <summary>
+    /// Property validation metadata.
+    /// </summary>
+    public class ValidationMetadata
+    {
+        /// <summary>
+        /// Id.
+        /// </summary>
+        public int ValidationMetadataId { get; set; }
+
+        /// <summary>
+        /// Type name.
+        /// </summary>
+        public string TypeName { get; set; }
+
+        /// <summary>
+        /// The name of property.
+        /// </summary>
+        public string PropertyName { get; set; }
+
+        /// <summary>
+        /// Property is required.
+        /// </summary>
+        public bool IsRequired { get; set; }
+
+        /// <summary>
+        /// Sets MaxLength for property.
+        /// </summary>
+        public int? MaxLength { get; set; }
+    }
+}

--- a/samples/SampleAlternativeContractResolver/Program.cs
+++ b/samples/SampleAlternativeContractResolver/Program.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+namespace SampleAlternativeNamingStrategy
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            BuildWebHost(args).Run();
+        }
+
+        public static IWebHost BuildWebHost(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                // Needed for using scoped services (for example DbContext) in validators
+                //.UseDefaultServiceProvider(options => options.ValidateScopes = false)
+                .UseStartup<Startup>()
+                .Build();
+    }
+}

--- a/samples/SampleAlternativeContractResolver/SampleAlternativeNamingStrategy.csproj
+++ b/samples/SampleAlternativeContractResolver/SampleAlternativeNamingStrategy.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <AssemblyName>SampleAlternativeNamingStrategy</AssemblyName>
+    <RootNamespace>SampleAlternativeNamingStrategy</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+
+    <PackageReference Include="FluentValidation.AspNetCore" Version="8.3.0" />
+
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.7" />
+
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />
+
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.6" />
+    <!--PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="0.4.0" /-->
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MicroElements.Swashbuckle.FluentValidation\MicroElements.Swashbuckle.FluentValidation.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/SampleAlternativeContractResolver/Startup.cs
+++ b/samples/SampleAlternativeContractResolver/Startup.cs
@@ -1,0 +1,116 @@
+﻿using System.Linq;
+using FluentValidation;
+using FluentValidation.AspNetCore;
+using MicroElements.Swashbuckle.FluentValidation;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Serialization;
+using SampleAlternativeNamingStrategy.DbModels;
+using Swashbuckle.AspNetCore.Swagger;
+
+namespace SampleAlternativeNamingStrategy
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // HttpContextServiceProviderValidatorFactory requires access to HttpContext
+            services.AddHttpContextAccessor();
+
+            var jsonContractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new SnakeCaseNamingStrategy()
+            };
+
+            services
+                .AddMvc()
+                // Adds fluent validators to Asp.net
+                .AddFluentValidation(c =>
+                {
+                    c.RegisterValidatorsFromAssemblyContaining<Startup>();
+                    // Optionally set validator factory if you have problems with scope resolve inside validators.
+                    c.ValidatorFactoryType = typeof(HttpContextServiceProviderValidatorFactory);
+                })
+                .AddJsonOptions(o => o.SerializerSettings.ContractResolver = jsonContractResolver);
+
+            // Register all validators as IValidator?
+            var serviceDescriptors = services.Where(descriptor => descriptor.ServiceType.GetInterfaces().Contains(typeof(IValidator))).ToList();
+            serviceDescriptors.ForEach(descriptor => services.Add(ServiceDescriptor.Transient(typeof(IValidator), descriptor.ImplementationType)));
+
+            // One more way to set custom factory.
+            //services = services.Replace(ServiceDescriptor.Scoped<IValidatorFactory, ScopedServiceProviderValidatorFactory>());
+
+            //IOptions<SwaggerGeneratorOptions>
+            //services.AddO
+            services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v1", new Info { Title = "My API", Version = "v1" });
+                // Adds fluent validation rules to swagger
+                c.AddFluentValidationRules(jsonContractResolver);
+            });
+
+            // Adds logging
+            services.AddLogging(builder => builder.AddConsole().AddFilter(level => true));
+
+            // Register database
+            services.AddDbContext<BloggingDbContext>(
+                options => options.UseInMemoryDatabase("validationDB"),
+                ServiceLifetime.Scoped);
+
+            //services.AddTransient<Func<BloggingDbContext>>(provider => provider.GetService<BloggingDbContext>);
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            app
+                .UseMvc()
+                // Adds swagger
+                .UseSwagger()
+
+                // Use scoped swagger if you have problems with scoped services in validators
+                //.UseScopedSwagger();
+            ;
+
+            // Adds swagger UI
+            app.UseSwaggerUI(c =>
+            {
+                c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
+            });
+
+            // Seed database (NOT PRODUCTION CODE)
+            TestDatabaseSeed(app);
+        }
+
+        private static void TestDatabaseSeed(IApplicationBuilder app)
+        {
+            var bloggingContext = app.ApplicationServices.CreateScope().ServiceProvider.GetService<BloggingDbContext>();
+            if (!EnumerableExtensions.Any(bloggingContext.Metadata))
+            {
+                // Example of defining rules dynamically from database.
+                bloggingContext.Metadata.Add(new ValidationMetadata
+                {
+                    ValidationMetadataId = 1,
+                    TypeName = typeof(Blog).Name,
+                    PropertyName = nameof(Blog.Author),
+                    IsRequired = true,
+                    MaxLength = 7
+                });
+                bloggingContext.SaveChanges();
+            }
+        }
+    }
+}

--- a/samples/SampleAlternativeContractResolver/ValidatorFactories/CustomValidatorFactory.cs
+++ b/samples/SampleAlternativeContractResolver/ValidatorFactories/CustomValidatorFactory.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentValidation;
+
+namespace SampleAlternativeNamingStrategy.ValidatorFactories
+{
+    /// <summary>
+    /// <see cref="IValidatorFactory"/> that works with registered validators.
+    /// </summary>
+    public class CustomValidatorFactory : IValidatorFactory
+    {
+        private readonly List<IValidator> _validators;
+
+        public CustomValidatorFactory(IEnumerable<IValidator> validators)
+        {
+            _validators = validators.ToList();
+        }
+
+        /// <inheritdoc />
+        public IValidator<T> GetValidator<T>()
+        {
+            return _validators.FirstOrDefault(validator => validator.CanValidateInstancesOfType(typeof(T))) as IValidator<T>;
+        }
+
+        /// <inheritdoc />
+        public IValidator GetValidator(Type type)
+        {
+            return _validators.FirstOrDefault(validator => validator.CanValidateInstancesOfType(type));
+        }
+    }
+}

--- a/samples/SampleAlternativeContractResolver/ValidatorFactories/ScopedServiceProviderValidatorFactory.cs
+++ b/samples/SampleAlternativeContractResolver/ValidatorFactories/ScopedServiceProviderValidatorFactory.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Diagnostics;
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SampleAlternativeNamingStrategy.ValidatorFactories
+{
+    /// <summary>
+    /// <see cref="IValidatorFactory"/> like default <see cref="FluentValidation.AspNetCore.ServiceProviderValidatorFactory"/>.
+    /// The main difference that this factory tries to get <see cref="IValidator"/> on new scope if first try fails.
+    /// </summary>
+    public class ScopedServiceProviderValidatorFactory : ValidatorFactoryBase
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        /// <summary>
+        /// Creates new instance of <see cref="ScopedServiceProviderValidatorFactory"/>.
+        /// </summary>
+        /// <param name="serviceProvider"><see cref="IServiceProvider"/>.</param>
+        public ScopedServiceProviderValidatorFactory(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        public override IValidator CreateInstance(Type validatorType)
+        {
+            try
+            {
+                return _serviceProvider.GetService(validatorType) as IValidator;
+            }
+            catch (InvalidOperationException)
+            {
+                using (_serviceProvider.CreateScope())
+                    return _serviceProvider.CreateScope().ServiceProvider.GetService(validatorType) as IValidator;
+            }
+        }
+    }
+}

--- a/samples/SampleAlternativeContractResolver/Validators/BasicRequestValidator.cs
+++ b/samples/SampleAlternativeContractResolver/Validators/BasicRequestValidator.cs
@@ -1,0 +1,17 @@
+﻿using FluentValidation;
+using SampleAlternativeNamingStrategy.Contracts;
+
+namespace SampleAlternativeNamingStrategy.Validators
+{
+    public class BasicRequestValidator : AbstractValidator<BasicGetRequest>
+    {
+        public BasicRequestValidator()
+        {
+            RuleFor(x => x.StandardHeaders).SetValidator(new StandardHeadersValidator());
+            RuleFor(x => x.ValueFromHeader).MaximumLength(10);
+
+            RuleFor(x => x.ValueFromHeader).NotEmpty().WithMessage("Missing value from header");
+            RuleFor(x => x.ValueFromQuery).NotEmpty().WithMessage("Missing value from query");
+        }
+    }
+}

--- a/samples/SampleAlternativeContractResolver/Validators/BlogValidator.cs
+++ b/samples/SampleAlternativeContractResolver/Validators/BlogValidator.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using FluentValidation;
+using SampleAlternativeNamingStrategy.DbModels;
+
+namespace SampleAlternativeNamingStrategy.Validators
+{
+    /// <summary>
+    /// Sample validator with database dependency.
+    /// </summary>
+    public class BlogValidator : AbstractValidator<Blog>
+    {
+        public BlogValidator(BloggingDbContext dbContext)
+        {
+            // Case0: No dependency on DbContext
+            RuleFor(blog => blog.BlogId).NotEmpty();
+            RuleFor(blog => blog.Url).NotNull();
+
+            // Case1: You need DbContext for runtime validation.
+            // DbContext can be null on swagger generation and active on request validation.
+            RuleFor(blog => blog.Url)
+                .Must(url => dbContext.Blogs.Count(b => b.Url == url) == 0)
+                .WithMessage("Url must be unique");
+
+            // Case2: You need DbContext for defining rules.
+            // DbContext must be active on swagger generation!!!
+            var propertyMetadata = dbContext.Metadata
+                .FirstOrDefault(metadata => metadata.TypeName == nameof(Blog) && metadata.PropertyName == nameof(Blog.Author));
+            if (propertyMetadata != null)
+            {
+                var ruleBuilder = RuleFor(blog => blog.Author);
+                if (propertyMetadata.IsRequired)
+                    ruleBuilder.NotNull();
+                if (propertyMetadata.MaxLength.HasValue)
+                    ruleBuilder.MaximumLength(propertyMetadata.MaxLength.Value);
+            }
+        }
+    }
+}

--- a/samples/SampleAlternativeContractResolver/Validators/Constants.cs
+++ b/samples/SampleAlternativeContractResolver/Validators/Constants.cs
@@ -1,0 +1,8 @@
+﻿namespace SampleAlternativeNamingStrategy.Validators
+{
+    public class Constants
+    {
+        public const string GuidRegex =
+            "^([0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12})$";
+    }
+}

--- a/samples/SampleAlternativeContractResolver/Validators/CustomerValidator.cs
+++ b/samples/SampleAlternativeContractResolver/Validators/CustomerValidator.cs
@@ -1,0 +1,56 @@
+﻿using System.Threading.Tasks;
+using FluentValidation;
+using SampleAlternativeNamingStrategy.Contracts;
+
+namespace SampleAlternativeNamingStrategy.Validators
+{
+    public class CustomerValidator : AbstractValidator<Customer>
+    {
+        public CustomerValidator()
+        {
+            When(customer => customer.Id == 1, () =>
+            {
+                RuleFor(customer => customer.Discount)
+                    .NotEmpty()
+                    .WithMessage("This WILL NOT be in the OpenAPI  spec.");
+            });
+
+            RuleFor(customer => customer.Discount)
+                .ExclusiveBetween(4, 5)
+                .WithMessage("This WILL be in the OpenAPI spec.");
+            RuleFor(customer => customer.Discount)
+                .NotEmpty()
+                .WhenAsync((customer, token) => Task.FromResult(customer.Id == 1))
+                .WithMessage("This WILL NOT be in the OpenAPI spec.");
+
+            RuleFor(customer => customer.Surname)
+                .NotEmpty();
+            RuleFor(customer => customer.Forename)
+                .NotEmpty()
+                .WithMessage("Please specify a first name");
+
+            Include(new CustomerAddressValidator());
+        }
+    }
+
+    internal class CustomerAddressValidator : AbstractValidator<Customer>
+    {
+        public CustomerAddressValidator()
+        {
+            UnlessAsync((customer, token) => Task.FromResult(customer.Surname == "Test"), () =>
+            {
+                RuleFor(customer => customer.Discount)
+                    .NotEmpty()
+                    .WithMessage("This WILL NOT be in the OpenAPI spec.");
+            });
+
+            RuleFor(customer => customer.Discount)
+                .NotEmpty()
+                .Unless(customer => customer.Surname == "Test")
+                .WithMessage("This WILL NOT be in the OpenAPI spec.");
+
+            RuleFor(customer => customer.Address)
+                .Length(20, 250);
+        }
+    }
+}

--- a/samples/SampleAlternativeContractResolver/Validators/StandardHeadersValidator.cs
+++ b/samples/SampleAlternativeContractResolver/Validators/StandardHeadersValidator.cs
@@ -1,0 +1,21 @@
+﻿using FluentValidation;
+using SampleAlternativeNamingStrategy.Contracts;
+
+namespace SampleAlternativeNamingStrategy.Validators
+{
+    public class StandardHeadersValidator : AbstractValidator<StandardHeaders>
+    {
+        public StandardHeadersValidator()
+        {
+            RuleFor(x => x.TransactionId)
+                .NotNull().WithMessage("Missing TransactionId in header")
+                .NotEmpty().WithMessage("Value missing for TransactionId")
+                .MinimumLength(8);
+
+            RuleFor(x => x.RequestId)
+                .NotNull().WithMessage("Missing RequestId in header")
+                .NotEmpty().WithMessage("Value missing for RequestId")
+                .Matches(Constants.GuidRegex);
+        }
+    }
+}

--- a/src/MicroElements.Swashbuckle.FluentValidation/FluentValidationRules.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/FluentValidationRules.cs
@@ -7,6 +7,7 @@ using FluentValidation.Validators;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json.Serialization;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -17,6 +18,7 @@ namespace MicroElements.Swashbuckle.FluentValidation
     /// </summary>
     public class FluentValidationRules : ISchemaFilter
     {
+        private readonly IContractResolver _contractResolver;
         private readonly IValidatorFactory _validatorFactory;
         private readonly ILogger _logger;
         private readonly IReadOnlyList<FluentValidationRule> _rules;
@@ -24,14 +26,17 @@ namespace MicroElements.Swashbuckle.FluentValidation
         /// <summary>
         /// Creates new instance of <see cref="FluentValidationRules"/>
         /// </summary>
+        /// <param name="contractResolver">Contract resolver</param>
         /// <param name="validatorFactory">Validator factory.</param>
         /// <param name="rules">External FluentValidation rules. Rule with the same name replaces default rule.</param>
         /// <param name="loggerFactory"><see cref="ILoggerFactory"/> for logging. Can be null.</param>
         public FluentValidationRules(
+            [CanBeNull] IContractResolver contractResolver = null,
             [CanBeNull] IValidatorFactory validatorFactory = null,
             [CanBeNull] IEnumerable<FluentValidationRule> rules = null,
             [CanBeNull] ILoggerFactory loggerFactory = null)
         {
+            _contractResolver = contractResolver;
             _validatorFactory = validatorFactory;
             _logger = loggerFactory?.CreateLogger(typeof(FluentValidationRules)) ?? NullLogger.Instance;
             _rules = CreateDefaultRules();
@@ -54,6 +59,11 @@ namespace MicroElements.Swashbuckle.FluentValidation
             {
                 _logger.LogWarning(0, "ValidatorFactory is not provided. Please register FluentValidation.");
                 return;
+            }
+
+            if (_contractResolver == null)
+            {
+                _logger.LogInformation(0, "ContractResolver is not provided. Using simple property names.");
             }
 
             IValidator validator = null;
@@ -86,9 +96,13 @@ namespace MicroElements.Swashbuckle.FluentValidation
             var lazyLog = new LazyLog(_logger,
                 logger => logger.LogDebug($"Applying FluentValidation rules to swagger schema for type '{context.SystemType}'."));
 
+            JsonObjectContract contract = _contractResolver?.ResolveContract(context.SystemType) as JsonObjectContract;
+
             foreach (var key in schema?.Properties?.Keys ?? Array.Empty<string>())
             {
-                var validators = validator.GetValidatorsForMemberIgnoreCase(key);
+                var memberName = GetMemberName(contract, key);
+
+                var validators = validator.GetValidatorsForMemberIgnoreCase(memberName);
 
                 foreach (var propertyValidator in validators)
                 {
@@ -110,6 +124,11 @@ namespace MicroElements.Swashbuckle.FluentValidation
                     }
                 }
             }
+        }
+
+        private string GetMemberName(JsonObjectContract contract, string key)
+        {
+            return contract?.Properties?.FirstOrDefault(p => p.PropertyName == key)?.UnderlyingName ?? key;
         }
 
         private void AddRulesFromIncludedValidators(Schema schema, SchemaFilterContext context, IValidator validator)

--- a/src/MicroElements.Swashbuckle.FluentValidation/FluentValidationRulesRegistrator.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/FluentValidationRulesRegistrator.cs
@@ -1,5 +1,6 @@
 ﻿using MicroElements.Swashbuckle.FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Serialization;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 // ReSharper disable once CheckNamespace
@@ -17,6 +18,17 @@ namespace Swashbuckle.AspNetCore.Swagger
         public static void AddFluentValidationRules(this SwaggerGenOptions options)
         {
             options.SchemaFilter<FluentValidationRules>();
+            options.OperationFilter<FluentValidationOperationFilter>();
+        }
+
+        /// <summary>
+        /// Adds fluent validation rules to swagger.
+        /// </summary>
+        /// <param name="options">Swagger options.</param>
+        /// <param name="contractResolver">Contract resolver.</param>
+        public static void AddFluentValidationRules(this SwaggerGenOptions options, IContractResolver contractResolver)
+        {
+            options.SchemaFilter<FluentValidationRules>(contractResolver);
             options.OperationFilter<FluentValidationOperationFilter>();
         }
     }


### PR DESCRIPTION
I opened issue #42 (under a different account) and thought I'd give it a shot and work on a fix.

With this PR, I added the ability to pass an IContractResolver when registering fluent validation rules.
And then in FluentValidationRules, if a contract resolver was provided, I use that to get the C# property that maps to the schema property, and use that to get the validators instead.

I also added a sample project that highlights this working with snake case naming.

In the case of #42, you'd pass a DefaultContractResolver to the registration method and it would fix the original issue.

Happy to change this however you see fit.  You can also just throw this out if you don't see this as problem worth fixing. 