### PR TITLE
Fix for invalid documentation for validation rules containing a condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Changes in 3.0.0-rc.3:
+* Updated FluentValidation to version >= 8.3
+* Fixed invalid documentation on validation rules containing a condition #38
+
 # Changes in 3.0.0-rc.2:
 * Swashbuckle.AspNetCore updated to version >= 5.0.0-rc4
 * Fixed: #37 (FluentValidationOperationFilter now uses swachbuckle interface to determine json settings)

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Note: For WebApi see: https://github.com/micro-elements/MicroElements.Swashbuckl
 ### 1. Reference packages in your web project:
 
 ```xml
-<PackageReference Include="FluentValidation.AspNetCore" Version="8.1.3" />
-<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="2.2.0" />
+<PackageReference Include="FluentValidation.AspNetCore" Version="8.3.0" />
+<PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="3.0.0-rc.3" />
 <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
 ```
 
@@ -70,7 +70,7 @@ MicroElements.Swashbuckle.FluentValidation | Swashbuckle.AspNetCore | FluentVali
 ---------|----------|---------
 [1.1.0, 2.0.0) | [3.0.0, 4.0.0) | >=7.2.0
 [2.0.0, 3.0.0) | [4.0.0, 5.0.0) | >=8.1.3
-[3.0.0, 4.0.0) | [5.0.0-rc3, 6.0.0) | >=8.1.3
+[3.0.0, 4.0.0) | [5.0.0-rc4, 6.0.0) | >=8.3.0
 
 ## Sample application
 

--- a/src/MicroElements.Swashbuckle.FluentValidation/Extensions.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/Extensions.cs
@@ -84,5 +84,15 @@ namespace MicroElements.Swashbuckle.FluentValidation
 
             return source;
         }
+
+        /// <summary>
+        /// Returns a <see cref="bool"/> indicating if the <paramref name="propertyValidator"/> is conditional.
+        /// </summary>
+        /// <param name="propertyValidator"></param>
+        /// <returns></returns>
+        internal static bool HasNoCondition(this IPropertyValidator propertyValidator)
+        {
+            return propertyValidator?.Options?.Condition == null && propertyValidator?.Options?.AsyncCondition == null;
+        }
     }
 }

--- a/src/MicroElements.Swashbuckle.FluentValidation/FluentValidationRules.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/FluentValidationRules.cs
@@ -131,7 +131,7 @@ namespace MicroElements.Swashbuckle.FluentValidation
             {
                 new FluentValidationRule("Required")
                 {
-                    Matches = propertyValidator => propertyValidator is INotNullValidator || propertyValidator is INotEmptyValidator,
+                    Matches = propertyValidator => (propertyValidator is INotNullValidator || propertyValidator is INotEmptyValidator) && propertyValidator.HasNoCondition(),
                     Apply = context =>
                     {
                         if (context.Schema.Required == null)
@@ -142,7 +142,7 @@ namespace MicroElements.Swashbuckle.FluentValidation
                 },
                 new FluentValidationRule("NotEmpty")
                 {
-                    Matches = propertyValidator => propertyValidator is INotEmptyValidator,
+                    Matches = propertyValidator => propertyValidator is INotEmptyValidator && propertyValidator.HasNoCondition(),
                     Apply = context =>
                     {
                         context.Schema.Properties[context.PropertyKey].MinLength = 1;
@@ -150,7 +150,7 @@ namespace MicroElements.Swashbuckle.FluentValidation
                 },
                 new FluentValidationRule("Length")
                 {
-                    Matches = propertyValidator => propertyValidator is ILengthValidator,
+                    Matches = propertyValidator => propertyValidator is ILengthValidator && propertyValidator.HasNoCondition(),
                     Apply = context =>
                     {
                         var lengthValidator = (ILengthValidator)context.PropertyValidator;
@@ -166,7 +166,7 @@ namespace MicroElements.Swashbuckle.FluentValidation
                 },
                 new FluentValidationRule("Pattern")
                 {
-                    Matches = propertyValidator => propertyValidator is IRegularExpressionValidator,
+                    Matches = propertyValidator => propertyValidator is IRegularExpressionValidator && propertyValidator.HasNoCondition(),
                     Apply = context =>
                     {
                         var regularExpressionValidator = (IRegularExpressionValidator)context.PropertyValidator;
@@ -175,7 +175,7 @@ namespace MicroElements.Swashbuckle.FluentValidation
                 },
                 new FluentValidationRule("Comparison")
                 {
-                    Matches = propertyValidator => propertyValidator is IComparisonValidator,
+                    Matches = propertyValidator => propertyValidator is IComparisonValidator && propertyValidator.HasNoCondition(),
                     Apply = context =>
                     {
                         var comparisonValidator = (IComparisonValidator)context.PropertyValidator;
@@ -207,7 +207,7 @@ namespace MicroElements.Swashbuckle.FluentValidation
                 },
                 new FluentValidationRule("Between")
                 {
-                    Matches = propertyValidator => propertyValidator is IBetweenValidator,
+                    Matches = propertyValidator => propertyValidator is IBetweenValidator && propertyValidator.HasNoCondition(),
                     Apply = context =>
                     {
                         var betweenValidator = (IBetweenValidator)context.PropertyValidator;

--- a/src/MicroElements.Swashbuckle.FluentValidation/MicroElements.Swashbuckle.FluentValidation.csproj
+++ b/src/MicroElements.Swashbuckle.FluentValidation/MicroElements.Swashbuckle.FluentValidation.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="8.1.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
+    <PackageReference Include="FluentValidation" Version="8.3.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="[5.0.0-rc4, 6)" />
   </ItemGroup>
 
 </Project>

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>rc.2</VersionSuffix>
+    <VersionSuffix>rc.3</VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
fixes #38

The inner workings of conditionals has been changed in FluentValidation 8.3.
Before the 8.3 version the FluentValidation validators that contained a conditional would be of type DelegatingValidator, and because the type DelegatingValidator was not checked anywhere in the FluentValidationRules class in the MicroElements.Swashbuckle.FluentValidation package, no documentation for these conditionals were added.

FluentValidation 8.3 deprecated the DelegatingValidator and used a different mechanism of storing the conditions. The validators that contains a condition will be the normal type (e.g. NotNullValidator) and now contains the properties Condition and AsyncCondition.