### PR TITLE
CollectionPropertyRules are no longer exposed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Changes in 3.0.0-rc.5:
+* FluentValidation property rules of type CollectionValidationRules (RuleForEach()) are no longer exposed #49. 
+
 # Changes in 3.0.0-rc.4:
 * Swashbuckle.AspNetCore updated to version >= 5.0.0-rc4 (breaking changes: IApiModelResolver was removed from API)
 * New IgnoreAllStringComparer was invented to solve problem with different property name formatting: camelCase, PascalCase, snake_case, kebab-case

--- a/src/MicroElements.Swashbuckle.FluentValidation/Extensions.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/Extensions.cs
@@ -23,9 +23,25 @@ namespace MicroElements.Swashbuckle.FluentValidation
         {
             return (validator as IEnumerable<IValidationRule>)
                 .NotNull()
-                .OfType<PropertyRule>()
+                .GetPropertyRules()
                 .Where(propertyRule => propertyRule.HasNoCondition() && propertyRule.PropertyName.EqualsIgnoreAll(name))
                 .SelectMany(propertyRule => propertyRule.Validators);
+        }
+
+        /// <summary>
+        /// Removes all IValidationRules that are not a PropertyRule.
+        /// A CollectionPropertyRule should not be exposed in the OpenAPI specification #49.
+        /// </summary>
+        internal static IEnumerable<PropertyRule> GetPropertyRules(
+            this IEnumerable<IValidationRule> validationRules)
+        {
+            foreach (var validationRule in validationRules)
+            {
+                if (validationRule.GetType() == typeof(PropertyRule))
+                {
+                    yield return (PropertyRule)validationRule;
+                }
+            }
         }
 
         /// <summary>

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>rc.4</VersionSuffix>
+    <VersionSuffix>rc.5</VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Hi, 

I had an issue described here: https://github.com/micro-elements/MicroElements.Swashbuckle.FluentValidation/issues/49

This PR fixed that. I don't think it makes sense to expose CollectionValidationRules in OpenAPI.