### PR TITLE
Set dependency to SwaggerGen

### DIFF
--- a/samples/SampleWebApi/SampleWebApi.csproj
+++ b/samples/SampleWebApi/SampleWebApi.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MicroElements.Swashbuckle.FluentValidation/MicroElements.Swashbuckle.FluentValidation.csproj
+++ b/src/MicroElements.Swashbuckle.FluentValidation/MicroElements.Swashbuckle.FluentValidation.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="[10.0.0, 11)" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="[6.0.0, 7)" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="[6.0.0, 7)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
@petriashev for your upcoming v5 release supporting FV 10.0 I'd like to change your dependency from the swashbuckle metapackage which includes SwaggerUI as a dependency and change it over to the SwaggerGen package which is UI independent.  This will let people who setup Swashbuckle with ReDoc to not have to download the swagger UI stuff as part of the build process.