### PR TITLE
sets min compatibility to Swashbuckle.AspNetCore 6.3.0 | fixes #101

### DIFF
--- a/src/MicroElements.Swashbuckle.FluentValidation/MicroElements.Swashbuckle.FluentValidation.csproj
+++ b/src/MicroElements.Swashbuckle.FluentValidation/MicroElements.Swashbuckle.FluentValidation.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="[10.0.0, 11)" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="[6.0.2, 7)" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="[6.3.0, 7)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
the most recent Swashbuckle.AspNetCore(6.3.0) has changed ISchemaGenerator.GenerateSchema signature.

This PR changes the minimal required version to fix compatibility problems.