### PR TITLE
Allow for conditional rules and validators

### DIFF
--- a/samples/SampleWebApi/Controllers/ConditionRulesController.cs
+++ b/samples/SampleWebApi/Controllers/ConditionRulesController.cs
@@ -1,0 +1,105 @@
+﻿using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using System.Text.RegularExpressions;
+using MicroElements.OpenApi.FluentValidation;
+
+namespace SampleWebApi.Controllers
+{
+    [Route("api/[controller]")]
+    public class ConditionRulesController : Controller
+    {
+        [HttpPost("[action]")]
+        public IActionResult AddClub([FromBody] Club club)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            return Ok(club.ClubNumber);
+        }
+    }
+
+    public interface IIdOwner
+    {
+        public string Id { get; init; }
+    }
+
+    public interface IEmailOwner
+    {
+        public string? Email { get; init; }
+    }
+
+    public class Club : IEmailOwner, IIdOwner
+    {
+        public string Id { get; init; } = null!;
+        public string ClubNumber { get; init; } = null!;
+        public string? Email { get; init; }
+        public int? Source { get; init; }
+    }
+
+    public class ClubValidator : AbstractValidator<Club>
+    {
+        public ClubValidator()
+        {
+            this.IncludeConditionalRulesInSchema();
+
+            RuleFor(x => x.Id)
+                .NotNull();
+
+            RuleFor(x => x.ClubNumber)
+                .Length(4);
+
+            RuleFor(x => x)
+                .SetValidator(new IdOwnerValidator());
+
+            RuleFor(x => x)
+                .SetValidator(new EmailOwnerValidator())
+                .When(x => x.ClubNumber == "8088");
+
+            When((_, _) => false, () =>
+            {
+                RuleFor(x => x.ClubNumber)
+                    .NotEmpty()
+                    .Matches(new Regex(@"^\d$"))
+                    .When(x => x.Id == "1");
+
+                RuleFor(x => x.Source)
+                    .LessThanOrEqualTo(16)
+                    .When(x => x is not null)
+                    .ExcludeConditionalRuleFromSchema();
+            });
+        }
+    }
+
+    public class IdOwnerValidator : AbstractValidator<IIdOwner>
+    {
+        public IdOwnerValidator()
+        {
+            this.IncludeConditionalRulesInSchema();
+
+            RuleFor(x => x.Id)
+                .MaximumLength(7)
+                .When(x => true);
+
+            RuleFor(x => x.Id)
+                .MinimumLength(2)
+                .When(x => false)
+                .ExcludeConditionalRuleFromSchema();
+        }
+    }
+
+    public class EmailOwnerValidator : AbstractValidator<IEmailOwner>
+    {
+        public EmailOwnerValidator()
+        {
+            RuleFor(x => x.Email)
+                .EmailAddress()
+                .MaximumLength(128)
+                .NotNull()
+                .NotEmpty()
+                .When(x => true)
+                .IncludeConditionalRuleInSchema();
+        }
+    }
+}

--- a/samples/SampleWebApi/Startup.cs
+++ b/samples/SampleWebApi/Startup.cs
@@ -61,6 +61,9 @@ namespace SampleWebApi
             {
                 c.SwaggerDoc("v1", new OpenApiInfo(){ Title = "My API", Version = "v1" });
                 c.EnableAnnotations(enableAnnotationsForInheritance: true, enableAnnotationsForPolymorphism: true);
+
+                // [Optional] Use native C#'s reference type nullable feature
+                //c.SupportNonNullableReferenceTypes();
             });
 
             // [Optional] Add INameResolver (SystemTextJsonNameResolver will be registered by default)

--- a/src/MicroElements.OpenApi.FluentValidation/FluentValidation/FluentValidationExtensions.cs
+++ b/src/MicroElements.OpenApi.FluentValidation/FluentValidation/FluentValidationExtensions.cs
@@ -58,12 +58,27 @@ namespace MicroElements.OpenApi.FluentValidation
                 .Where(propertyRule => propertyRule.PropertyRule.PropertyName.EqualsIgnoreAll(name));
         }
 
+        /// <summary>
+        /// Include conditional rules and validators that are defined in the current validator
+        /// to be generated in Swagger's schema.
+        /// </summary>
+        /// <typeparam name="TValidator">Validator type.</typeparam>
+        /// <param name="validator">Validator.</param>
+        /// <returns>validator.</returns>
         public static TValidator IncludeConditionalRulesInSchema<TValidator>(this TValidator validator)
             where TValidator : IValidator
         {
             return validator.IncludeConditionalRulesInSchema(_defaultAllowedConditionalValidatorTypes);
         }
 
+        /// <summary>
+        /// Include conditional rules and specified validators that are defined in the current validator
+        /// to be generated in Swagger's schema.
+        /// </summary>
+        /// <typeparam name="TValidator">Validator type.</typeparam>
+        /// <param name="validator">Validator.</param>
+        /// <param name="allowedConditionalValidatorTypes">Allowed conditional validator types for the defined validator.</param>
+        /// <returns>validator.</returns>
         public static TValidator IncludeConditionalRulesInSchema<TValidator>(
             this TValidator validator,
             IEnumerable<Type> allowedConditionalValidatorTypes)
@@ -77,11 +92,26 @@ namespace MicroElements.OpenApi.FluentValidation
             return validator;
         }
 
+        /// <summary>
+        /// Include conditioanl validators on the current rule builder to be generated in Swagger's schema.
+        /// </summary>
+        /// <typeparam name="T">Type of object being validated.</typeparam>
+        /// <typeparam name="TProperty">Type of property being validated.</typeparam>
+        /// <param name="ruleBuilder">The rule builder on which the validator should be defined.</param>
+        /// <returns>ruleBuilder.</returns>
         public static IRuleBuilder<T, TProperty> IncludeConditionalRuleInSchema<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder)
         {
             return ruleBuilder.IncludeConditionalRuleInSchema(_defaultAllowedConditionalValidatorTypes);
         }
 
+        /// <summary>
+        /// Include the specified conditional validators on the current rule builder to be generated in Swagger's schema.
+        /// </summary>
+        /// <typeparam name="T">Type of object being validated.</typeparam>
+        /// <typeparam name="TProperty">Type of property being validated.</typeparam>
+        /// <param name="ruleBuilder">The rule builder on which the validator should be defined.</param>
+        /// <param name="allowedConditionalValidatorTypes">Allowed conditional validator types for the defined builder.</param>
+        /// <returns>ruleBuilder.</returns>
         public static IRuleBuilder<T, TProperty> IncludeConditionalRuleInSchema<T, TProperty>(
             this IRuleBuilder<T, TProperty> ruleBuilder,
             IEnumerable<Type> allowedConditionalValidatorTypes)
@@ -95,6 +125,14 @@ namespace MicroElements.OpenApi.FluentValidation
             return ruleBuilder;
         }
 
+        /// <summary>
+        /// Exlude all conditional validators on the current rule builder from being generated in Swagger's schema.
+        /// Only applies to conditional rules or validators.
+        /// </summary>
+        /// <typeparam name="T">Type of object being validated.</typeparam>
+        /// <typeparam name="TProperty">Type of property being validated.</typeparam>
+        /// <param name="ruleBuilder">The rule builder on which the validator should be defined.</param>
+        /// <returns>ruleBuilder.</returns>
         public static IRuleBuilder<T, TProperty> ExcludeConditionalRuleFromSchema<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder)
         {
             if (TryGetRuleFromBuilder(ruleBuilder, out IValidationRule<T, TProperty> rule)
@@ -180,6 +218,7 @@ namespace MicroElements.OpenApi.FluentValidation
         /// Gets validators for <see cref="IValidationRule"/>.
         /// </summary>
         /// <param name="validationRule">Validator.</param>
+        /// <param name="context">ValidationRuleInfo.</param>
         /// <returns>enumeration.</returns>
         public static IEnumerable<IPropertyValidator> GetValidators(
             this IValidationRule validationRule,

--- a/src/MicroElements.OpenApi.FluentValidation/FluentValidation/FluentValidationSchemaBuilder.cs
+++ b/src/MicroElements.OpenApi.FluentValidation/FluentValidation/FluentValidationSchemaBuilder.cs
@@ -43,7 +43,7 @@ namespace MicroElements.OpenApi.FluentValidation
 
                 foreach (var validationRuleInfo in validationRuleInfoList)
                 {
-                    var propertyValidators = validationRuleInfo.PropertyRule.GetValidators();
+                    var propertyValidators = validationRuleInfo.PropertyRule.GetValidators(validationRuleInfo);
 
                     foreach (var propertyValidator in propertyValidators)
                     {
@@ -92,7 +92,7 @@ namespace MicroElements.OpenApi.FluentValidation
                 .ToArrayDebug();
 
             var propertiesWithChildAdapters = validationRules
-                .Select(context => (context.PropertyRule, context.PropertyRule.GetValidators().OfType<IChildValidatorAdaptor>().ToArray()))
+                .Select(context => (context.PropertyRule, context.PropertyRule.GetValidators(context).OfType<IChildValidatorAdaptor>().ToArray()))
                 .ToArrayDebug();
 
             foreach ((IValidationRule propertyRule, IChildValidatorAdaptor[] childAdapters) in propertiesWithChildAdapters)

--- a/src/MicroElements.OpenApi.FluentValidation/FluentValidation/ValidationRuleInfo.cs
+++ b/src/MicroElements.OpenApi.FluentValidation/FluentValidation/ValidationRuleInfo.cs
@@ -25,6 +25,8 @@ namespace MicroElements.OpenApi.FluentValidation
         /// </summary>
         public ReflectionContext? ReflectionContext { get; init; }
 
+        public IValidator? Validator { get; init; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ValidationRuleInfo"/> class.
         /// </summary>
@@ -34,11 +36,13 @@ namespace MicroElements.OpenApi.FluentValidation
         public ValidationRuleInfo(
             IValidationRule propertyRule,
             bool isCollectionRule,
-            ReflectionContext? reflectionContext)
+            ReflectionContext? reflectionContext,
+            IValidator? validator)
         {
             PropertyRule = propertyRule;
             IsCollectionRule = isCollectionRule;
             ReflectionContext = reflectionContext;
+            Validator = validator;
         }
     }
 }


### PR DESCRIPTION
Hey,

I work at a finance company and our security policy requires us to provide a full open API schema that should include also conditional rules.
I've added additional configurations to "ISchemaGenerationOptions" that will allow such behavior.
The additional options are: "AllowConditionalRules", "AllowConditionalValidators" and "AllowedConditionalValidatorTypes".
The filtering itself will occur in "FluentValidationExtensions" because that's where the existing "HasNoCondition" check happens.
So I had to pass "ISchemaGenerationOptions" all the way to "GetValidators" and "GetPropertyRules" methods in "FluentValidationExtensions" and to filter the conditional rules and validators based on the new parameters in "ISchemaGenerationOptions".
By default, those changes would not effect any existing behaviors unless the user will set "AllowConditionalRules" or "AllowConditionalValidators" to "true" (default for both is "false").

Thanks,