### PR TITLE
Stack Overflow Exception On Recursive Validators - Fixes #121

### DIFF
--- a/src/MicroElements.OpenApi.FluentValidation/FluentValidation/FluentValidationSchemaBuilder.cs
+++ b/src/MicroElements.OpenApi.FluentValidation/FluentValidation/FluentValidationSchemaBuilder.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) MicroElements. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using FluentValidation;
-using FluentValidation.Validators;
-
-using MicroElements.OpenApi.Core;
-
-using Microsoft.Extensions.Logging;
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using FluentValidation;
+using FluentValidation.Validators;
+using MicroElements.OpenApi.Core;
+using Microsoft.Extensions.Logging;
 
 namespace MicroElements.OpenApi.FluentValidation
 {

--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/TreeValidatorTest.cs
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/TreeValidatorTest.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using FluentValidation;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using Xunit;
+
+namespace MicroElements.Swashbuckle.FluentValidation.Tests
+{
+    public class TreeValidatorTest : UnitTestBase
+    {
+        /// <summary>
+        /// A simple recursive data structure
+        /// </summary>
+        public class Node
+        {
+            public string Id { get; set; }
+            public List<Node> Nodes = new();
+        }
+
+        public class NodeValidator : AbstractValidator<Node>
+        {
+            public NodeValidator()
+            {
+                // Recursive validation example I found on this closed "issue".  Used it as the base for this test.
+                // https://github.com/FluentValidation/FluentValidation/issues/1568
+                RuleForEach(r => r.Nodes).SetValidator(this);
+                RuleFor(r => r.Id).NotEmpty();
+            }
+        }
+
+        [Fact]
+        public void recursive_validator_works()
+        {
+            // *********************************
+            // FluentValidation swagger behavior
+            // *********************************
+
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = SchemaGenerator(new NodeValidator())
+                .GenerateSchema(typeof(Node), schemaRepository);
+
+            // if we have gotten this far, huzza, no stack overflow.
+            
+            // MicroElements schema validation should work normally on other non-recursive properties 
+            var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
+            var idProperty = schema.Properties[nameof(Node.Id)];
+            idProperty.Type.Should().Be("string");
+            idProperty.MinLength.Should().Be(1);
+        }
+    }
+}


### PR DESCRIPTION
This PR proposes a minimal fix for stack overflow exceptions raised when using this library with recursive validators.

I created a simple test based off an old "issue" I found that more or less captures the use case:
https://github.com/FluentValidation/FluentValidation/issues/1568 

I left a blank 'no-op' style catch to rescue the infinite recursion - but I am not sure if there would be a more desirable action to take instead. "Nothing" seemed the least intrusive thing to do. 

 Attempts to fix #121