### PR TITLE
Fix test project compilation errors

### DIFF
--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/MicroElements.Swashbuckle.FluentValidation.Tests.csproj
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/MicroElements.Swashbuckle.FluentValidation.Tests.csproj
@@ -9,7 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="8.2.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" PrivateAssets="all" />
   </ItemGroup>

--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/SwaggerTestHost.cs
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/SwaggerTestHost.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using FluentValidation;
+
 using Microsoft.AspNetCore.Mvc;
-#endif
 using MicroElements.OpenApi.FluentValidation;
 using MicroElements.Swashbuckle.FluentValidation.AspNetCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace MicroElements.Swashbuckle.FluentValidation.Tests;
 
@@ -60,6 +61,9 @@ public class SwaggerTestHost
     public SwaggerTestHost GenerateSchema<TModel>(out OpenApiSchema schema)
     {
         var schemaGenerator = ServiceProvider.GetService<ISchemaGenerator>();
+        if (schemaGenerator == null)
+            throw new InvalidOperationException("ISchemaGenerator service not found. Make sure to call Configure() first.");
+        
         var openApiSchema = schemaGenerator.GenerateSchema(typeof(TModel), SchemaRepository);
         schema = SchemaRepository.Schemas[openApiSchema.Reference.Id];
         return this;


### PR DESCRIPTION
- Remove orphaned #endif directive in SwaggerTestHost.cs
- Add missing package references (FluentValidation.AspNetCore, Swashbuckle.AspNetCore.Annotations)
- Add null check for ISchemaGenerator to prevent NullReferenceException