### PR TITLE
Bump version to 7.0.1 (SemVer compliance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changes in 7.0.0.1
+# Changes in 7.0.1
 - Fixed: FluentValidation rules not applied to `[FromForm]` parameters (Issue #170)
   - Added `RequestBody` processing in `FluentValidationOperationFilter` for `multipart/form-data` and `application/x-www-form-urlencoded` content types
 

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>7.0.0.1</VersionPrefix>
+    <VersionPrefix>7.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
NuGet requires Semantic Versioning (MAJOR.MINOR.PATCH). Changed from 7.0.0.1 to 7.0.1.

