### PR TITLE
Fix multiple .Matches() rules displayed incorrectly (Issue #204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
   - `Include`: conditional rules are included in the schema (useful when `.When()` is a null-guard and constraints should still appear)
   - `IncludeWithWarning`: same as `Include` but logs a warning for each conditional rule included
   - Usage: `options.ConditionalRules = ConditionalRulesMode.Include;`
+- Fixed: Multiple `.Matches()` rules on one property displayed incorrectly — only the first pattern shown, property duplicated (Issue #204)
+  - Multiple patterns were placed into separate `allOf` subschemas, which Swagger UI/Redoc/Scalar collapse, keeping only the first `pattern`
+  - Now multiple `.Matches()` rules are combined into a single `pattern` via lookahead assertions (e.g. `(?=[\s\S]*(?:[a-z]))(?=[\s\S]*(?:[A-Z]))`), preserving `.Matches()` semantics and rendering correctly
+  - Applied to all providers: Swashbuckle, `MicroElements.AspNetCore.OpenApi.FluentValidation`, and NSwag (NSwag previously kept only the last pattern)
+  - Changed: `SchemaGenerationOptions.UseAllOfForMultipleRules` default `true` → `false`; set it to `true` to keep the legacy `allOf` representation
 
 # Changes in 7.1.4
 - Added: `FluentValidationOperationTransformer` (`IOpenApiOperationTransformer`) for `MicroElements.AspNetCore.OpenApi.FluentValidation` (Issue #200)

--- a/src/MicroElements.AspNetCore.OpenApi.FluentValidation/DefaultFluentValidationRuleProvider.cs
+++ b/src/MicroElements.AspNetCore.OpenApi.FluentValidation/DefaultFluentValidationRuleProvider.cs
@@ -114,8 +114,8 @@ namespace MicroElements.AspNetCore.OpenApi.FluentValidation
                     }
                     else
                     {
-                        // Set new pattern
-                        schemaProperty.Pattern = regularExpressionValidator.Expression;
+                        // Combine multiple patterns into a single 'pattern' (renders correctly in Swagger UI/Redoc/Scalar).
+                        schemaProperty.Pattern = PatternCombiner.Combine(schemaProperty.Pattern, regularExpressionValidator.Expression);
                     }
                 });
 

--- a/src/MicroElements.NSwag.FluentValidation/NSwagFluentValidationRuleProvider.cs
+++ b/src/MicroElements.NSwag.FluentValidation/NSwagFluentValidationRuleProvider.cs
@@ -145,7 +145,10 @@ namespace MicroElements.NSwag.FluentValidation
                         var regularExpressionValidator = (IRegularExpressionValidator) context.PropertyValidator;
 
                         var schema = context.Schema.Schema;
-                        schema.Properties[context.PropertyKey].Pattern = regularExpressionValidator.Expression;
+                        var schemaProperty = schema.Properties[context.PropertyKey];
+
+                        // Combine multiple patterns into a single 'pattern' (renders correctly in Swagger UI/Redoc/Scalar).
+                        schemaProperty.Pattern = PatternCombiner.Combine(schemaProperty.Pattern, regularExpressionValidator.Expression);
                     },
                 },
                 new FluentValidationRule("Comparison")

--- a/src/MicroElements.OpenApi.FluentValidation/FluentValidation/ISchemaGenerationOptions.cs
+++ b/src/MicroElements.OpenApi.FluentValidation/FluentValidation/ISchemaGenerationOptions.cs
@@ -28,6 +28,7 @@ namespace MicroElements.OpenApi.FluentValidation
         /// When <see langword="false"/> (default) multiple <c>.Matches()</c> rules are combined into a single
         /// <c>pattern</c> via lookahead assertions, which renders correctly in Swagger UI, Redoc and Scalar.
         /// When <see langword="true"/> each pattern is placed into a separate <c>allOf</c> subschema.
+        /// Note: the NSwag provider always combines patterns and ignores this option.
         /// </summary>
         bool UseAllOfForMultipleRules { get; }
 

--- a/src/MicroElements.OpenApi.FluentValidation/FluentValidation/ISchemaGenerationOptions.cs
+++ b/src/MicroElements.OpenApi.FluentValidation/FluentValidation/ISchemaGenerationOptions.cs
@@ -24,7 +24,10 @@ namespace MicroElements.OpenApi.FluentValidation
         bool SetNotNullableIfMinimumGreaterThenZero { get; }
 
         /// <summary>
-        /// Gets a value indicating whether schema generator should use AllOf for multiple rules (for example for multiple patterns).
+        /// Gets a value indicating whether schema generator should use <c>allOf</c> for multiple patterns.
+        /// When <see langword="false"/> (default) multiple <c>.Matches()</c> rules are combined into a single
+        /// <c>pattern</c> via lookahead assertions, which renders correctly in Swagger UI, Redoc and Scalar.
+        /// When <see langword="true"/> each pattern is placed into a separate <c>allOf</c> subschema.
         /// </summary>
         bool UseAllOfForMultipleRules { get; }
 
@@ -96,10 +99,13 @@ namespace MicroElements.OpenApi.FluentValidation
         public bool SetNotNullableIfMinimumGreaterThenZero { get; set; } = false;
 
         /// <summary>
-        /// Gets or sets a value indicating whether schema generator should use AllOf for multiple rules (for example for multiple patterns).
-        /// Default: true.
+        /// Gets or sets a value indicating whether schema generator should use <c>allOf</c> for multiple patterns.
+        /// When <see langword="false"/> (default) multiple <c>.Matches()</c> rules are combined into a single
+        /// <c>pattern</c> via lookahead assertions, which renders correctly in Swagger UI, Redoc and Scalar.
+        /// When <see langword="true"/> each pattern is placed into a separate <c>allOf</c> subschema.
+        /// Default: false.
         /// </summary>
-        public bool UseAllOfForMultipleRules { get; set; } = true;
+        public bool UseAllOfForMultipleRules { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the validator search strategy.

--- a/src/MicroElements.OpenApi.FluentValidation/FluentValidation/PatternCombiner.cs
+++ b/src/MicroElements.OpenApi.FluentValidation/FluentValidation/PatternCombiner.cs
@@ -23,6 +23,8 @@ namespace MicroElements.OpenApi.FluentValidation
         /// Used to detect a pattern already combined by this class.
         /// The full prefix (not just <c>"(?="</c>) is matched on purpose, so a user-supplied
         /// pattern that merely starts with a lookahead is not mistaken for combiner output.
+        /// Accepted edge case: a user pattern that itself begins with exactly this prefix is
+        /// still treated as combiner output, producing a valid but slightly less strict result.
         /// </summary>
         private const string LookaheadPrefix = "(?=[\\s\\S]*(?:";
 
@@ -30,13 +32,16 @@ namespace MicroElements.OpenApi.FluentValidation
         /// Combines an existing <c>pattern</c> with an additional regular expression.
         /// </summary>
         /// <param name="existing">The current <c>pattern</c> value, or <see langword="null"/> if none was set.</param>
-        /// <param name="newPattern">The additional regular expression to combine.</param>
+        /// <param name="newPattern">The additional regular expression to combine. A null or empty value is a no-op.</param>
         /// <returns>
         /// <paramref name="newPattern"/> as is when there is no existing pattern;
         /// otherwise a single regular expression that requires both to match.
         /// </returns>
         public static string Combine(string? existing, string newPattern)
         {
+            if (string.IsNullOrEmpty(newPattern))
+                return existing ?? string.Empty;
+
             if (string.IsNullOrEmpty(existing))
                 return newPattern;
 

--- a/src/MicroElements.OpenApi.FluentValidation/FluentValidation/PatternCombiner.cs
+++ b/src/MicroElements.OpenApi.FluentValidation/FluentValidation/PatternCombiner.cs
@@ -1,0 +1,53 @@
+// Copyright (c) MicroElements. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace MicroElements.OpenApi.FluentValidation
+{
+    /// <summary>
+    /// Combines multiple regular expressions into a single OpenAPI <c>pattern</c>.
+    /// </summary>
+    /// <remarks>
+    /// OpenAPI/JSON Schema allows only one <c>pattern</c> per schema, so multiple
+    /// <c>.Matches()</c> rules on one property cannot be expressed as separate keywords.
+    /// This combiner joins them into a single regular expression using lookahead
+    /// assertions, which keeps the FluentValidation <c>.Matches()</c> semantics
+    /// (<see cref="System.Text.RegularExpressions.Regex.IsMatch(string, string)"/> — "contains a match")
+    /// and renders correctly in Swagger UI, Redoc and Scalar.
+    /// </remarks>
+    public static class PatternCombiner
+    {
+        /// <summary>
+        /// Opening part of a lookahead produced by <see cref="Wrap"/>.
+        /// Used to detect a pattern already combined by this class.
+        /// The full prefix (not just <c>"(?="</c>) is matched on purpose, so a user-supplied
+        /// pattern that merely starts with a lookahead is not mistaken for combiner output.
+        /// </summary>
+        private const string LookaheadPrefix = "(?=[\\s\\S]*(?:";
+
+        /// <summary>
+        /// Combines an existing <c>pattern</c> with an additional regular expression.
+        /// </summary>
+        /// <param name="existing">The current <c>pattern</c> value, or <see langword="null"/> if none was set.</param>
+        /// <param name="newPattern">The additional regular expression to combine.</param>
+        /// <returns>
+        /// <paramref name="newPattern"/> as is when there is no existing pattern;
+        /// otherwise a single regular expression that requires both to match.
+        /// </returns>
+        public static string Combine(string? existing, string newPattern)
+        {
+            if (string.IsNullOrEmpty(existing))
+                return newPattern;
+
+            // 'existing' was already combined by this method: just append a new lookahead.
+            if (existing!.StartsWith(LookaheadPrefix, StringComparison.Ordinal))
+                return existing + Wrap(newPattern);
+
+            // 'existing' is a plain single pattern: wrap both into lookaheads.
+            return Wrap(existing) + Wrap(newPattern);
+        }
+
+        private static string Wrap(string pattern) => $"{LookaheadPrefix}{pattern}))";
+    }
+}

--- a/src/MicroElements.Swashbuckle.FluentValidation/DefaultFluentValidationRuleProvider.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/DefaultFluentValidationRuleProvider.cs
@@ -114,8 +114,8 @@ namespace MicroElements.Swashbuckle.FluentValidation
                     }
                     else
                     {
-                        // Set new pattern
-                        schemaProperty.Pattern = regularExpressionValidator.Expression;
+                        // Combine multiple patterns into a single 'pattern' (renders correctly in Swagger UI/Redoc/Scalar).
+                        schemaProperty.Pattern = PatternCombiner.Combine(schemaProperty.Pattern, regularExpressionValidator.Expression);
                     }
                 });
 

--- a/test/MicroElements.AspNetCore.OpenApi.FluentValidation.Tests/AspNetCoreOpenApiTests.cs
+++ b/test/MicroElements.AspNetCore.OpenApi.FluentValidation.Tests/AspNetCoreOpenApiTests.cs
@@ -330,6 +330,25 @@ public class AspNetCoreOpenApiTests : IClassFixture<AspNetCoreOpenApiTests.TestW
         scores.GetProperty("minItems").GetInt32().Should().Be(1);
     }
 
+    /// <summary>
+    /// Issue #204: multiple <c>.Matches()</c> rules on one property are combined
+    /// into a single <c>pattern</c> instead of separate <c>allOf</c> subschemas.
+    /// </summary>
+    [Fact]
+    public async Task MultipleMatchRules_ShouldCombineIntoSinglePattern()
+    {
+        var schemas = await GetSchemasAsync();
+
+        var model = schemas.GetProperty("TestPasswordModel");
+        var password = model.GetProperty("properties").GetProperty("password");
+
+        password.GetProperty("pattern").GetString()
+            .Should().Be("(?=[\\s\\S]*(?:[a-z]))(?=[\\s\\S]*(?:[A-Z]))(?=[\\s\\S]*(?:[0-9]))");
+
+        password.TryGetProperty("allOf", out _).Should().BeFalse(
+            "patterns are merged into a single 'pattern'");
+    }
+
     [Fact]
     public void TransformerCanResolveWithoutScope()
     {

--- a/test/MicroElements.AspNetCore.OpenApi.FluentValidation.Tests/Program.cs
+++ b/test/MicroElements.AspNetCore.OpenApi.FluentValidation.Tests/Program.cs
@@ -23,5 +23,6 @@ app.MapGet("/api/search", ([AsParameters] TestQueryParameters query) => Results.
 app.MapGet("/api/filter", ([AsParameters] TestFilterParams filter) => Results.Ok(filter));
 app.MapPost("/api/request", (TestRequestWithNested dto) => Results.Ok(dto));
 app.MapPost("/api/collections", (TestCollectionModel model) => Results.Ok(model));
+app.MapPost("/api/password", (TestPasswordModel model) => Results.Ok(model));
 
 app.Run();

--- a/test/MicroElements.AspNetCore.OpenApi.FluentValidation.Tests/TestModels.cs
+++ b/test/MicroElements.AspNetCore.OpenApi.FluentValidation.Tests/TestModels.cs
@@ -131,6 +131,26 @@ public class TestCollectionModelValidator : AbstractValidator<TestCollectionMode
     }
 }
 
+// Issue #204: multiple .Matches() rules on one property
+public class TestPasswordModel
+{
+    public string Password { get; set; } = string.Empty;
+}
+
+public class TestPasswordModelValidator : AbstractValidator<TestPasswordModel>
+{
+    public TestPasswordModelValidator()
+    {
+        RuleFor(x => x.Password)
+            .NotEmpty()
+            .MinimumLength(8)
+            .MaximumLength(256)
+            .Matches("[a-z]")
+            .Matches("[A-Z]")
+            .Matches("[0-9]");
+    }
+}
+
 // BigInteger model for Issue #146
 public class TestBigIntegerModel
 {

--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/MultipleMatchRules.cs
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/MultipleMatchRules.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using System.Text.RegularExpressions;
 using FluentAssertions;
 using FluentValidation;
 #if OPENAPI_V2
@@ -65,6 +67,83 @@ namespace MicroElements.Swashbuckle.FluentValidation.Tests
             var schema = new SchemaRepository().GenerateSchemaForValidator(new PhoneEntity.Validator());
             var numberProp = schema.GetProperty(nameof(PhoneEntity.MobilePhoneNumber))!;
             numberProp.GetTypeString().Should().Be("string");
+        }
+
+        private class CreateUserRequest
+        {
+            public string Password { get; set; }
+
+            public class Validator : AbstractValidator<CreateUserRequest>
+            {
+                public Validator()
+                {
+                    RuleFor(x => x.Password)
+                        .NotEmpty()
+                        .MinimumLength(8)
+                        .MaximumLength(256)
+                        .Matches("[a-z]").WithMessage("'Password' must contain at least one lowercase letter.")
+                        .Matches("[A-Z]").WithMessage("'Password' must contain at least one uppercase letter.")
+                        .Matches("[0-9]").WithMessage("'Password' must contain at least one digit.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// By default multiple <c>.Matches()</c> rules are combined into a single 'pattern'.
+        /// https://github.com/micro-elements/MicroElements.Swashbuckle.FluentValidation/issues/204
+        /// </summary>
+        [Fact]
+        public void multiple_match_rules_combined_into_single_pattern()
+        {
+            var schema = new SchemaRepository().GenerateSchemaForValidator(new CreateUserRequest.Validator());
+            var passwordProp = schema.GetProperty(nameof(CreateUserRequest.Password))!;
+
+            const string expected = "(?=[\\s\\S]*(?:[a-z]))(?=[\\s\\S]*(?:[A-Z]))(?=[\\s\\S]*(?:[0-9]))";
+
+            passwordProp.Pattern.Should().Be(expected);
+            (passwordProp.AllOf?.Count ?? 0).Should().Be(0, "patterns are merged into a single 'pattern'");
+
+            // The combined pattern keeps the .Matches() semantics: all three constraints are required.
+            Regex.IsMatch("Abcdef12", expected).Should().BeTrue();
+            Regex.IsMatch("abcdefgh", expected).Should().BeFalse("missing uppercase and digit");
+            Regex.IsMatch("ABCDEF12", expected).Should().BeFalse("missing lowercase");
+        }
+
+        /// <summary>
+        /// Edge case: a user-supplied pattern that itself starts with a lookahead must still be
+        /// wrapped when combined, so the combined patterns stay independent.
+        /// </summary>
+        [Fact]
+        public void multiple_match_rules_combine_user_lookahead_pattern()
+        {
+            var validator = new InlineValidator<CreateUserRequest>();
+            validator.RuleFor(x => x.Password)
+                .Matches("(?=x)")
+                .Matches("[0-9]");
+
+            var schema = new SchemaRepository().GenerateSchemaForValidator(validator);
+            var passwordProp = schema.GetProperty(nameof(CreateUserRequest.Password))!;
+
+            // The first pattern is wrapped too — not appended as-is.
+            passwordProp.Pattern.Should().Be("(?=[\\s\\S]*(?:(?=x)))(?=[\\s\\S]*(?:[0-9]))");
+        }
+
+        /// <summary>
+        /// With <see cref="MicroElements.OpenApi.FluentValidation.SchemaGenerationOptions.UseAllOfForMultipleRules"/>
+        /// the legacy 'allOf' representation is preserved.
+        /// </summary>
+        [Fact]
+        public void multiple_match_rules_use_allOf_when_opted_in()
+        {
+            var schema = new SchemaRepository().GenerateSchemaForValidator(
+                new CreateUserRequest.Validator(),
+                configureSchemaGenerationOptions: options => options.UseAllOfForMultipleRules = true);
+            var passwordProp = schema.GetProperty(nameof(CreateUserRequest.Password))!;
+
+            passwordProp.Pattern.Should().BeNull();
+            passwordProp.AllOf.Should().NotBeNull();
+            passwordProp.AllOf!.Select(s => ((OpenApiSchema)s).Pattern)
+                .Should().BeEquivalentTo("[a-z]", "[A-Z]", "[0-9]");
         }
     }
 }

--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/MultipleMatchRules.cs
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/MultipleMatchRules.cs
@@ -67,6 +67,9 @@ namespace MicroElements.Swashbuckle.FluentValidation.Tests
             var schema = new SchemaRepository().GenerateSchemaForValidator(new PhoneEntity.Validator());
             var numberProp = schema.GetProperty(nameof(PhoneEntity.MobilePhoneNumber))!;
             numberProp.GetTypeString().Should().Be("string");
+
+            // Two .Matches() rules are combined into a single 'pattern'; anchored patterns are preserved.
+            numberProp.Pattern.Should().Be("(?=[\\s\\S]*(?:^3))(?=[\\s\\S]*(?:^\\d*$))");
         }
 
         private class CreateUserRequest


### PR DESCRIPTION
## Problem

Issue #204: a property with several `.Matches()` rules (e.g. a password validator) renders incorrectly in the OpenAPI document — the property is duplicated and only the **first** pattern is shown.

**Root cause:** multiple `.Matches()` rules were placed into separate `allOf` subschemas, each carrying one `pattern`. Renderers (Swagger UI, Redoc, Scalar) merge `allOf` into the property, and a duplicate `pattern` keyword cannot be merged — only the first survives. The other patterns are effectively lost from the displayed schema.

## Fix

Combine multiple patterns into a single valid `pattern` via lookahead assertions, e.g.:

```
(?=[\s\S]*(?:[a-z]))(?=[\s\S]*(?:[A-Z]))(?=[\s\S]*(?:[0-9]))
```

This preserves FluentValidation `.Matches()` semantics (`Regex.IsMatch` — "contains a match") and renders correctly in all tools.

- New `PatternCombiner` helper in `MicroElements.OpenApi.FluentValidation`.
- Applied in all three rule providers: Swashbuckle, `MicroElements.AspNetCore.OpenApi.FluentValidation`, and NSwag (NSwag previously kept only the **last** pattern).
- `SchemaGenerationOptions.UseAllOfForMultipleRules` default changed `true` → `false`. Set it to `true` to keep the legacy `allOf` representation (semantically valid, but not displayed by renderers).

## Behavior change

This changes the generated OpenAPI output for any property with 2+ `.Matches()` rules. The `allOf` representation remains available as an opt-in. Documented in `CHANGELOG.md`.

## Tests

- `MultipleMatchRules.cs`: combined pattern by default, regex semantics, user-supplied lookahead patterns, legacy `allOf` opt-in.
- `AspNetCoreOpenApiTests.cs`: integration test for the AspNetCore.OpenApi package.
- All tests green on net8.0 / net9.0 / net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)