### PR TITLE
Fix $ref orphaned with ChildRules/inline child validator (Issue #198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Changes in 7.1.6
+- Fixed: `$ref` still replaced with an inline copy (and the child component left orphaned) when nested object constraints come from `ChildRules` or an inline child validator (Issue #198, comment 4601720562)
+  - The 7.1.3 fix restored unmodified `$ref`s, but when the nested type had no standalone validator its component schema gained its `Required` only after the parent's inline snapshot, so the stale `Required` diverged and defeated the restore check — leaving an inline copy and an orphaned component
+  - Fix: the `Required` comparison in `HasValidationConstraintChanges` is now directional — restoration is only blocked when the inline copy carries a required entry the component lacks
+  - `SetValidator` (with a standalone child validator) was already correct; `BigInteger`/enum per-model constraints (Issues #146/#176) continue to work
+
 # Changes in 7.1.5
 - Added: `ConditionalRulesMode` option to control how `.When()`/`.Unless()` conditional rules are handled during schema generation (Issue #203)
   - `Exclude` (default): conditional rules are excluded from the schema (backward-compatible, existing behavior)

--- a/src/MicroElements.Swashbuckle.FluentValidation/OpenApi/OpenApiSchemaCompatibility.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/OpenApi/OpenApiSchemaCompatibility.cs
@@ -356,11 +356,17 @@ namespace MicroElements.OpenApi
             if (copy.Type != original.Type) return true;
             if (copy.Format != original.Format) return true;
 
-            // Check Required collection changes
+            // Check Required collection changes — directionally.
+            // The required set of a referenced object schema belongs on the shared component (it is applied
+            // there via SetValidator / ChildRules), and the inline snapshot taken on the parent may be stale
+            // relative to it. Issue #198 (comment 4601720562): with ChildRules / an inline child validator the
+            // nested type has no standalone validator, so its component schema is generated empty and only gains
+            // its Required AFTER the inline snapshot. A plain count/SetEquals check then saw the divergence and
+            // (wrongly) kept the inline copy, orphaning the component. Only block restoration when the inline
+            // copy carries a required entry the component lacks (the copy is authoritative for that field).
             var copyReq = copy.Required;
             var origReq = original.Required;
-            if (copyReq?.Count != origReq?.Count) return true;
-            if (copyReq != null && origReq != null && !copyReq.SetEquals(origReq)) return true;
+            if (copyReq is { Count: > 0 } && (origReq == null || !copyReq.IsSubsetOf(origReq))) return true;
 
             // Check AllOf collection changes (Pattern rule with UseAllOfForMultipleRules)
             var copyAllOfCount = copy.AllOf?.Count ?? 0;

--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/SchemaReferenceResolutionTests.cs
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/SchemaReferenceResolutionTests.cs
@@ -313,11 +313,14 @@ namespace MicroElements.Swashbuckle.FluentValidation.Tests
                 "CreateUserRequest.properties['user'] should be a $ref to CreateUserParams, not an inline copy (Issue #198 comment)");
 #endif
 
-            // Assert: the child component schema keeps its constraints
+            // Assert: the child component schema keeps ALL its constraints
             var paramsSchema = schemaRepository.Schemas["CreateUserParams"] as OpenApiSchema;
             paramsSchema.Should().NotBeNull();
-            var emailProp = OpenApiSchemaCompatibility.GetProperty(paramsSchema!, "Email", schemaRepository);
-            emailProp!.Format.Should().Be("email");
+            OpenApiSchemaCompatibility.GetProperty(paramsSchema!, "Email", schemaRepository)!.Format.Should().Be("email");
+            OpenApiSchemaCompatibility.GetProperty(paramsSchema!, "Name", schemaRepository)!.MaxLength.Should().Be(510);
+
+            // Assert: the required set lives on the child component (this is exactly what the orphan bug dropped)
+            paramsSchema!.Required.Should().Contain("Email").And.Contain("Name");
         }
 
         /// <summary>
@@ -382,11 +385,14 @@ namespace MicroElements.Swashbuckle.FluentValidation.Tests
                 "ChildRulesRequest.properties['user'] should be a $ref to ChildRulesParams, not an inline copy (Issue #198 comment)");
 #endif
 
-            // Assert: the child component keeps the inline ChildRules constraints
+            // Assert: the child component keeps ALL the inline ChildRules constraints
             var paramsSchema = schemaRepository.Schemas["ChildRulesParams"] as OpenApiSchema;
             paramsSchema.Should().NotBeNull();
-            var emailProp = OpenApiSchemaCompatibility.GetProperty(paramsSchema!, "Email", schemaRepository);
-            emailProp!.Format.Should().Be("email");
+            OpenApiSchemaCompatibility.GetProperty(paramsSchema!, "Email", schemaRepository)!.Format.Should().Be("email");
+            OpenApiSchemaCompatibility.GetProperty(paramsSchema!, "Name", schemaRepository)!.MaxLength.Should().Be(510);
+
+            // Assert: the required set lives on the child component (this is exactly what the orphan bug dropped)
+            paramsSchema!.Required.Should().Contain("Email").And.Contain("Name");
         }
     }
 }

--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/SchemaReferenceResolutionTests.cs
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/SchemaReferenceResolutionTests.cs
@@ -250,5 +250,143 @@ namespace MicroElements.Swashbuckle.FluentValidation.Tests
             minB.Should().Be(500, "ModelB minimum should be 500");
             maxB.Should().Be(1000, "ModelB maximum should be 1000");
         }
+
+        /// <summary>
+        /// Issue #198 (comment 4601720562 by jrgcubano): nested object with a child validator
+        /// that adds MULTIPLE constraints (Email format + MaximumLength) should still keep the
+        /// parent property as a $ref, and the child component schema must NOT become an orphan.
+        /// https://github.com/micro-elements/MicroElements.Swashbuckle.FluentValidation/issues/198#issuecomment-4601720562
+        /// </summary>
+        public class CreateUserRequest
+        {
+            public CreateUserParams User { get; set; }
+        }
+
+        public class CreateUserParams
+        {
+            public string Email { get; set; }
+
+            public string Name { get; set; }
+        }
+
+        public class CreateUserRequestValidator : AbstractValidator<CreateUserRequest>
+        {
+            public CreateUserRequestValidator()
+            {
+                RuleFor(a => a.User).NotEmpty().SetValidator(new CreateUserParamsValidator());
+            }
+        }
+
+        public class CreateUserParamsValidator : AbstractValidator<CreateUserParams>
+        {
+            public CreateUserParamsValidator()
+            {
+                RuleFor(a => a.Email).NotEmpty().EmailAddress();
+                RuleFor(a => a.Name).NotEmpty().MaximumLength(510);
+            }
+        }
+
+        [Fact]
+        public void SetValidator_With_MultiConstraint_Child_Should_Preserve_Ref()
+        {
+            // Arrange
+            var schemaRepository = new SchemaRepository();
+            var schemaGenerator = SchemaGenerator(new CreateUserRequestValidator(), new CreateUserParamsValidator());
+
+            // Act
+            var referenceSchema = schemaGenerator.GenerateSchema(typeof(CreateUserRequest), schemaRepository);
+            var requestSchema = schemaRepository.GetSchema(referenceSchema.GetRefId()!);
+
+            // Assert: CreateUserRequest schema should have "User" in required
+            requestSchema.Required.Should().Contain("User");
+
+            // Assert: CreateUserParams component schema should exist
+            schemaRepository.Schemas.Should().ContainKey("CreateUserParams");
+
+            // Assert: CreateUserRequest.properties["User"] should remain a $ref, not an inline copy
+            var userProp = requestSchema.Properties["User"];
+#if OPENAPI_V2
+            userProp.Should().BeOfType<OpenApiSchemaReference>(
+                "CreateUserRequest.properties['user'] should be a $ref to CreateUserParams, not an inline copy (Issue #198 comment)");
+#else
+            userProp.Reference.Should().NotBeNull(
+                "CreateUserRequest.properties['user'] should be a $ref to CreateUserParams, not an inline copy (Issue #198 comment)");
+#endif
+
+            // Assert: the child component schema keeps its constraints
+            var paramsSchema = schemaRepository.Schemas["CreateUserParams"] as OpenApiSchema;
+            paramsSchema.Should().NotBeNull();
+            var emailProp = OpenApiSchemaCompatibility.GetProperty(paramsSchema!, "Email", schemaRepository);
+            emailProp!.Format.Should().Be("email");
+        }
+
+        /// <summary>
+        /// Issue #198 (comment 4601720562): a nested object whose constraints are defined inline via
+        /// ChildRules (so the child type has NO standalone validator) must still keep the parent property
+        /// as a $ref, and the child component schema must NOT become an orphan.
+        /// Before the fix, the inline child component gained its Required only after the parent's inline
+        /// snapshot was taken, so the stale Required diverged and defeated ref restoration.
+        /// https://github.com/micro-elements/MicroElements.Swashbuckle.FluentValidation/issues/198#issuecomment-4601720562
+        /// </summary>
+        public class ChildRulesRequest
+        {
+            public ChildRulesParams User { get; set; }
+        }
+
+        public class ChildRulesParams
+        {
+            public string Email { get; set; }
+
+            public string Name { get; set; }
+        }
+
+        // NOTE: there is intentionally NO ChildRulesParamsValidator — the child constraints are inline.
+        public class ChildRulesRequestValidator : AbstractValidator<ChildRulesRequest>
+        {
+            public ChildRulesRequestValidator()
+            {
+                RuleFor(a => a.User)
+                    .NotEmpty()
+                    .ChildRules(u =>
+                    {
+                        u.RuleFor(c => c.Email).NotEmpty().EmailAddress();
+                        u.RuleFor(c => c.Name).NotEmpty().MaximumLength(510);
+                    });
+            }
+        }
+
+        [Fact]
+        public void ChildRules_Inline_Should_Preserve_Ref_For_Nested_Object()
+        {
+            // Arrange: only the request validator exists; the child type has no standalone validator.
+            var schemaRepository = new SchemaRepository();
+            var schemaGenerator = SchemaGenerator(new ChildRulesRequestValidator());
+
+            // Act
+            var referenceSchema = schemaGenerator.GenerateSchema(typeof(ChildRulesRequest), schemaRepository);
+            var requestSchema = schemaRepository.GetSchema(referenceSchema.GetRefId()!);
+
+            // Assert: request schema should have "User" in required
+            requestSchema.Required.Should().Contain("User");
+
+            // Assert: the child component schema should exist
+            schemaRepository.Schemas.Should().ContainKey("ChildRulesParams");
+
+            // Assert: User should remain a $ref, not an inline copy (and so ChildRulesParams is not orphaned)
+            var userProp = requestSchema.Properties["User"];
+#if OPENAPI_V2
+            userProp.Should().BeOfType<OpenApiSchemaReference>(
+                "ChildRulesRequest.properties['user'] should be a $ref to ChildRulesParams, not an inline copy (Issue #198 comment)");
+#else
+            userProp.Reference.Should().NotBeNull(
+                "ChildRulesRequest.properties['user'] should be a $ref to ChildRulesParams, not an inline copy (Issue #198 comment)");
+#endif
+
+            // Assert: the child component keeps the inline ChildRules constraints
+            var paramsSchema = schemaRepository.Schemas["ChildRulesParams"] as OpenApiSchema;
+            paramsSchema.Should().NotBeNull();
+            var emailProp = OpenApiSchemaCompatibility.GetProperty(paramsSchema!, "Email", schemaRepository);
+            emailProp!.Format.Should().Be("email");
+        }
     }
 }

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>7.1.5</VersionPrefix>
-    <VersionSuffix>beta.2</VersionSuffix>
+    <VersionPrefix>7.1.6</VersionPrefix>
+    <VersionSuffix>beta.1</VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Issue #198 follow-up (comment 4601720562)

The 7.1.3 fix for #198 (`SnapshotRefs` + `RestoreUnmodifiedRefs`) restored unmodified `$ref`s for nested objects validated via `SetValidator(new ChildValidator())`. But when the nested object's constraints come from **`ChildRules(...)`** (or any inline child validator) — i.e. the child type has **no standalone validator class** — the symptom returned: the parent property became a full inline copy and the child component was orphaned.

### Root cause
With no standalone child validator, the child's component schema is generated **empty**, so it gains its `Required` only **after** the parent's inline `$ref` snapshot is taken. The shallow inline copy shares `Properties` (so nested constraints leak in) but keeps its own stale, empty `Required`, which then diverges from the component. The old `Required` count/`SetEquals` check in `HasValidationConstraintChanges` saw the divergence and (wrongly) kept the inline copy, orphaning the component.

### Fix
Make the `Required` comparison **directional** — only block `$ref` restoration when the inline copy carries a required entry the component lacks (the copy is authoritative for that field). A stale-but-subset `Required` on the copy no longer blocks restoration.

```csharp
// before
if (copyReq?.Count != origReq?.Count) return true;
if (copyReq != null && origReq != null && !copyReq.SetEquals(origReq)) return true;
// after
if (copyReq is { Count: > 0 } && (origReq == null || !copyReq.IsSubsetOf(origReq))) return true;
```

> Note: an earlier attempt discriminated "DTO ref vs leaf ref" by *"the inline copy is an object with properties"* — that is **wrong**, because on OPENAPI_V2 `BigInteger` (and enums) render as a `$ref` to a schema that **also has properties**, which broke the per-model min/max isolation from #146. The directional `Required` check is the correct, minimal fix.

### Verification
- New regression tests in `SchemaReferenceResolutionTests.cs`:
  - `ChildRules_Inline_Should_Preserve_Ref_For_Nested_Object`
  - `SetValidator_With_MultiConstraint_Child_Should_Preserve_Ref`
- Full suite green on all TFMs: **net10.0 80/80**, **net8.0 94/94**, **net9.0 94/94**.
- Confirmed end-to-end through the real Swashbuckle pipeline (minimal API → `GetSwagger`): with `ChildRules`, `CreateUserRequest.user` is now `{ "$ref": "#/components/schemas/CreateUserParams" }` and `CreateUserParams` is no longer orphaned.
- `SetValidator`, `BigInteger`/enum (#146/#176), 8 mainstream + 5 other exotic nesting variants all remain correct.

Targets the new `release/v7.1.6-beta` line; bumps version to `7.1.6-beta.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
