### PR TITLE
Fix required leaf in optional nested [FromQuery] type wrongly marked required (Issue #209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Changes in 7.1.7
+- Fixed: A required leaf property inside an **optional** nested type bound via `[FromQuery]` was wrongly marked as a required parameter (Issue #209)
+  - The 7.1.1 fix (Issue #162) made nested `[FromQuery]` validation match the leaf property name, but `FluentValidationOperationFilter` then set `required` based solely on the leaf type, ignoring whether the ancestor segment of the dot-path was optional
+  - Because two nested properties of the same leaf type share one schema/validator (e.g. `OptionalSubType.SubProperty` and `RequiredSubType.SubProperty`), a `NotEmpty()` on the leaf marked **both** flattened parameters as required
+  - Fix: a flattened nested parameter is now marked `required` only when **every** ancestor segment of the dot-path is required — resolved from the action's root `[FromQuery]` type, combining the native schema `required` (e.g. the C# `required` modifier) with FluentValidation `NotNull`/`NotEmpty` rules
+  - Value constraints (e.g. `minLength`) still apply to an optional nested parameter when it is provided
+  - When the root container type cannot be resolved, prior behavior is preserved (no regression for existing nested-parameter scenarios)
+
 # Changes in 7.1.6
 - Fixed: `$ref` still replaced with an inline copy (and the child component left orphaned) when nested object constraints come from `ChildRules` or an inline child validator (Issue #198, comment 4601720562)
   - The 7.1.3 fix restored unmodified `$ref`s, but when the nested type had no standalone validator its component schema gained its `Required` only after the parent's inline snapshot, so the stale `Required` diverged and defeated the restore check — leaving an inline copy and an orphaned component

--- a/src/MicroElements.Swashbuckle.FluentValidation/Swashbuckle/FluentValidationOperationFilter.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/Swashbuckle/FluentValidationOperationFilter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using MicroElements.OpenApi;
 using MicroElements.OpenApi.Core;
 using MicroElements.OpenApi.FluentValidation;
@@ -173,7 +174,11 @@ namespace MicroElements.Swashbuckle.FluentValidation
                             logger: _logger,
                             schemaGenerationContext: schemaContext);
 
-                        if (OpenApiSchemaCompatibility.RequiredContains(schema, schemaPropertyName))
+                        // Issue #209: a required leaf is only a required parameter when the WHOLE dot-path
+                        // is required. For a flattened nested [FromQuery] parameter (e.g. "OptionalSubType.SubProperty")
+                        // an optional ancestor (e.g. an optional nested object) must keep the parameter optional.
+                        if (OpenApiSchemaCompatibility.RequiredContains(schema, schemaPropertyName)
+                            && IsParameterPathRequired(operationParameter.Name, context, schemaProvider))
                         {
 #if OPENAPI_V2
                             // In OpenApi 2.x, IOpenApiParameter.Required is read-only
@@ -244,6 +249,101 @@ namespace MicroElements.Swashbuckle.FluentValidation
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Determines whether a (possibly nested) operation parameter may be marked as required.
+        /// For a flattened nested [FromQuery] parameter (e.g. "OptionalSubType.SubProperty") the leaf
+        /// is a required parameter only when EVERY ancestor segment of the dot-path is itself required.
+        /// If any ancestor (e.g. an optional nested object) is not required, the parameter stays optional.
+        /// Issue #209.
+        /// </summary>
+        private bool IsParameterPathRequired(string parameterName, OperationFilterContext context, SwashbuckleSchemaProvider schemaProvider)
+        {
+            // Flat parameter: no ancestors to verify.
+            if (parameterName.IndexOf('.') < 0)
+                return true;
+
+            var segments = parameterName.Split('.');
+
+            // Resolve the root [FromQuery]/[AsParameters] type from the action method by matching the first segment.
+            var currentType = ResolveRootType(segments[0], context.MethodInfo);
+
+            // If the root type cannot be determined, preserve the prior behavior (mark required).
+            if (currentType == null)
+                return true;
+
+            // Walk every ancestor segment (all but the leaf); leaf requiredness is handled by the caller.
+            for (int i = 0; i < segments.Length - 1; i++)
+            {
+                if (!IsPropertyRequiredInType(currentType, segments[i], context, schemaProvider))
+                    return false;
+
+                var propertyInfo = currentType.GetProperty(segments[i], BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                if (propertyInfo == null)
+                    return true; // path does not map to a real property — preserve prior behavior
+
+                currentType = propertyInfo.PropertyType;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Finds the action parameter type that exposes <paramref name="firstSegment"/> as a property.
+        /// This is the root container of a flattened nested [FromQuery] parameter.
+        /// </summary>
+        private static Type? ResolveRootType(string firstSegment, MethodInfo? methodInfo)
+        {
+            if (methodInfo == null)
+                return null;
+
+            foreach (var parameter in methodInfo.GetParameters())
+            {
+                if (parameter.ParameterType.GetProperty(firstSegment, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase) != null)
+                    return parameter.ParameterType;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Checks whether <paramref name="propertyName"/> is required in <paramref name="containerType"/>,
+        /// combining the generated schema (native required, e.g. the C# 'required' modifier) with the
+        /// FluentValidation rules (NotNull/NotEmpty) of the container type's validator.
+        /// </summary>
+        private bool IsPropertyRequiredInType(Type containerType, string propertyName, OperationFilterContext context, SwashbuckleSchemaProvider schemaProvider)
+        {
+            OpenApiSchema schema = schemaProvider.GetSchemaForType(containerType);
+            if (schema.Properties == null || schema.Properties.Count == 0)
+                return false;
+
+            // Resolve the schema property key (handles camelCase / PascalCase differences).
+            var resolvedName = OpenApiSchemaCompatibility.GetProperties(schema)
+                .Select(property => property.Key)
+                .FirstOrDefault(key => key.EqualsIgnoreAll(propertyName)) ?? propertyName;
+
+            var validator = _validatorRegistry!.GetValidator(containerType);
+            if (validator != null)
+            {
+                var schemaContext = new SchemaGenerationContext(
+                    schemaRepository: context.SchemaRepository,
+                    schemaGenerator: context.SchemaGenerator,
+                    schema: schema,
+                    schemaType: containerType,
+                    rules: _rules,
+                    schemaGenerationOptions: _schemaGenerationOptions,
+                    schemaProvider: schemaProvider);
+
+                FluentValidationSchemaBuilder.ApplyRulesToSchema(
+                    schemaType: containerType,
+                    schemaPropertyNames: new[] { resolvedName },
+                    validator: validator,
+                    logger: _logger,
+                    schemaGenerationContext: schemaContext);
+            }
+
+            return OpenApiSchemaCompatibility.RequiredContains(schema, resolvedName);
         }
 
         private void ApplyRulesToRequestBody(OpenApiOperation operation, OperationFilterContext context, SwashbuckleSchemaProvider schemaProvider)

--- a/src/MicroElements.Swashbuckle.FluentValidation/Swashbuckle/FluentValidationOperationFilter.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/Swashbuckle/FluentValidationOperationFilter.cs
@@ -274,6 +274,11 @@ namespace MicroElements.Swashbuckle.FluentValidation
                 return true;
 
             // Walk every ancestor segment (all but the leaf); leaf requiredness is handled by the caller.
+            // Resolving ancestor requiredness registers the ancestor (container) schemas in the repository,
+            // exactly like the leaf container is registered above. Those unused [FromQuery] container schemas
+            // are removed by the Issue #180 cleanup when RemoveUnusedQuerySchemas is enabled. We must NOT
+            // remove them mid-loop: Swashbuckle's generator remembers already-generated types and would not
+            // re-register the component on the next GetSchemaForType call, leaving an unresolvable $ref.
             for (int i = 0; i < segments.Length - 1; i++)
             {
                 if (!IsPropertyRequiredInType(currentType, segments[i], context, schemaProvider))
@@ -292,6 +297,9 @@ namespace MicroElements.Swashbuckle.FluentValidation
         /// <summary>
         /// Finds the action parameter type that exposes <paramref name="firstSegment"/> as a property.
         /// This is the root container of a flattened nested [FromQuery] parameter.
+        /// Limitation: if several action parameters expose a property with the same name, the first
+        /// match wins. This is an unlikely edge case; a wrong guess only affects the required flag and
+        /// the conservative fallbacks keep prior behavior.
         /// </summary>
         private static Type? ResolveRootType(string firstSegment, MethodInfo? methodInfo)
         {
@@ -315,6 +323,11 @@ namespace MicroElements.Swashbuckle.FluentValidation
         private bool IsPropertyRequiredInType(Type containerType, string propertyName, OperationFilterContext context, SwashbuckleSchemaProvider schemaProvider)
         {
             OpenApiSchema schema = schemaProvider.GetSchemaForType(containerType);
+
+            // No properties to reason about — treat the ancestor as not required (safe-to-optional default,
+            // intentionally the opposite of IsParameterPathRequired's "assume required" fallback: there we
+            // could not resolve the path at all and keep prior behavior, here we positively know the type
+            // exposes nothing to require against).
             if (schema.Properties == null || schema.Properties.Count == 0)
                 return false;
 
@@ -323,6 +336,15 @@ namespace MicroElements.Swashbuckle.FluentValidation
                 .Select(property => property.Key)
                 .FirstOrDefault(key => key.EqualsIgnoreAll(propertyName)) ?? propertyName;
 
+            // GetSchemaForType runs the FluentValidationRules schema filter during generation, so the
+            // requiredness (native 'required' modifier + NotNull/NotEmpty rules) is usually already present.
+            // Check first to avoid the write side effect of re-applying rules on a shared cached schema.
+            if (OpenApiSchemaCompatibility.RequiredContains(schema, resolvedName))
+                return true;
+
+            // Fallback for setups whose schema generator has no FluentValidationRules filter: apply the
+            // container validator's rules explicitly, then re-check. _validatorRegistry is non-null here —
+            // ApplyInternal returns early when it is null, before any parameter processing.
             var validator = _validatorRegistry!.GetValidator(containerType);
             if (validator != null)
             {
@@ -341,9 +363,11 @@ namespace MicroElements.Swashbuckle.FluentValidation
                     validator: validator,
                     logger: _logger,
                     schemaGenerationContext: schemaContext);
+
+                return OpenApiSchemaCompatibility.RequiredContains(schema, resolvedName);
             }
 
-            return OpenApiSchemaCompatibility.RequiredContains(schema, resolvedName);
+            return false;
         }
 
         private void ApplyRulesToRequestBody(OpenApiOperation operation, OperationFilterContext context, SwashbuckleSchemaProvider schemaProvider)

--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/NestedFromQueryOptionalAncestorTest.cs
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/NestedFromQueryOptionalAncestorTest.cs
@@ -1,0 +1,144 @@
+// Copyright (c) MicroElements. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using FluentAssertions;
+using FluentValidation;
+using MicroElements.OpenApi.FluentValidation;
+using MicroElements.Swashbuckle.FluentValidation.Generation;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Options;
+#if !OPENAPI_V2
+using Microsoft.OpenApi.Models;
+#endif
+using Swashbuckle.AspNetCore.SwaggerGen;
+using Xunit;
+
+namespace MicroElements.Swashbuckle.FluentValidation.Tests
+{
+    /// <summary>
+    /// Issue #209: A required leaf property inside an OPTIONAL nested type bound via [FromQuery]
+    /// must not be marked as a required operation parameter. A flattened dot-path parameter
+    /// (e.g. "OptionalSubType.SubProperty") may be required only when EVERY ancestor segment of
+    /// the path is itself required. The value constraints (e.g. MinLength) still apply.
+    /// </summary>
+    public class NestedFromQueryOptionalAncestorTest : UnitTestBase
+    {
+        public sealed record class FilterType
+        {
+            public FilterSubType? OptionalSubType { get; init; }
+
+            public required FilterSubType RequiredSubType { get; init; }
+        }
+
+        public sealed record class FilterSubType
+        {
+            public string? SubProperty { get; init; }
+        }
+
+        public sealed class FilterTypeValidator : AbstractValidator<FilterType>
+        {
+            public FilterTypeValidator()
+            {
+                RuleFor(x => x.RequiredSubType).NotNull();
+            }
+        }
+
+        public sealed class FilterSubTypeValidator : AbstractValidator<FilterSubType>
+        {
+            public FilterSubTypeValidator()
+            {
+                RuleFor(x => x.SubProperty).NotEmpty();
+            }
+        }
+
+        // Real action method used as MethodInfo so the operation filter can resolve
+        // the root [FromQuery] type and walk the dot-path of nested parameters.
+        public string Get([FromQuery] FilterType filter) => filter.ToString();
+
+// OperationFilter integration tests require framework-specific OpenApi types.
+#if !OPENAPI_V2
+        /// <summary>
+        /// Issue #209: 'OptionalSubType' is optional, 'RequiredSubType' is required. Both expose a
+        /// nested 'SubProperty' with NotEmpty(). Only 'RequiredSubType.SubProperty' should be a
+        /// required query parameter; 'OptionalSubType.SubProperty' must stay optional.
+        /// </summary>
+        [Fact]
+        public void Required_LeafProperty_In_Optional_Nested_Type_Should_Not_Be_Required()
+        {
+            // Arrange
+            var schemaGeneratorOptions = new SchemaGeneratorOptions();
+            var schemaRepository = new SchemaRepository();
+            var schemaGenerator = SchemaGenerator(new FilterTypeValidator(), new FilterSubTypeValidator());
+
+            var schemaGenerationOptions = new SchemaGenerationOptions
+            {
+                NameResolver = new SystemTextJsonNameResolver(),
+                SchemaIdSelector = schemaGeneratorOptions.SchemaIdSelector,
+            };
+
+            var validatorRegistry = new ValidatorRegistry(
+                new IValidator[] { new FilterTypeValidator(), new FilterSubTypeValidator() },
+                new OptionsWrapper<SchemaGenerationOptions>(schemaGenerationOptions));
+
+            var metadataProvider = new EmptyModelMetadataProvider();
+
+            // Swashbuckle flattens [FromQuery] into params whose ModelMetadata.ContainerType is the leaf type.
+            var subPropMetadata = metadataProvider.GetMetadataForProperty(typeof(FilterSubType), nameof(FilterSubType.SubProperty));
+
+            var apiDescription = new ApiDescription();
+            apiDescription.ParameterDescriptions.Add(new ApiParameterDescription
+            {
+                Name = "OptionalSubType.SubProperty",
+                ModelMetadata = subPropMetadata,
+                Source = BindingSource.Query,
+            });
+            apiDescription.ParameterDescriptions.Add(new ApiParameterDescription
+            {
+                Name = "RequiredSubType.SubProperty",
+                ModelMetadata = subPropMetadata,
+                Source = BindingSource.Query,
+            });
+
+            var optionalParamSchema = new OpenApiSchema { Type = "string" };
+            var requiredParamSchema = new OpenApiSchema { Type = "string" };
+
+            var operation = new OpenApiOperation
+            {
+                Parameters = new List<OpenApiParameter>
+                {
+                    new OpenApiParameter { Name = "OptionalSubType.SubProperty", In = ParameterLocation.Query, Schema = optionalParamSchema },
+                    new OpenApiParameter { Name = "RequiredSubType.SubProperty", In = ParameterLocation.Query, Schema = requiredParamSchema },
+                },
+            };
+
+            var context = new OperationFilterContext(
+                apiDescription,
+                schemaGenerator,
+                schemaRepository,
+                typeof(NestedFromQueryOptionalAncestorTest).GetMethod(nameof(Get))!);
+
+            var operationFilter = new FluentValidationOperationFilter(
+                validatorRegistry: validatorRegistry,
+                schemaGenerationOptions: new OptionsWrapper<SchemaGenerationOptions>(schemaGenerationOptions));
+
+            // Act
+            operationFilter.Apply(operation, context);
+
+            // Assert: the NotEmpty value constraint applies to BOTH params (when provided, must be non-empty).
+            optionalParamSchema.MinLength.Should().Be(1,
+                because: "NotEmpty still constrains the value of SubProperty when it is provided");
+            requiredParamSchema.MinLength.Should().Be(1,
+                because: "NotEmpty still constrains the value of SubProperty when it is provided");
+
+            // Assert: required propagates ONLY when the whole dot-path is required.
+            operation.Parameters[1].Required.Should().BeTrue(
+                because: "RequiredSubType is required (NotNull) and SubProperty is required (NotEmpty) — the whole path is required");
+            operation.Parameters[0].Required.Should().BeFalse(
+                because: "OptionalSubType is optional, so the nested SubProperty must not become a required query parameter (Issue #209)");
+        }
+#endif
+    }
+}

--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/NestedFromQueryOptionalAncestorTest.cs
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/NestedFromQueryOptionalAncestorTest.cs
@@ -1,7 +1,9 @@
 // Copyright (c) MicroElements. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
+using System.Reflection;
 using FluentAssertions;
 using FluentValidation;
 using MicroElements.OpenApi.FluentValidation;
@@ -57,6 +59,81 @@ namespace MicroElements.Swashbuckle.FluentValidation.Tests
         // Real action method used as MethodInfo so the operation filter can resolve
         // the root [FromQuery] type and walk the dot-path of nested parameters.
         public string Get([FromQuery] FilterType filter) => filter.ToString();
+
+        // --- Three-level nesting fixtures (Issue #209, review item #5) ---
+        public sealed record class DeepRoot
+        {
+            public DeepMiddle? OptionalMiddle { get; init; }
+
+            public required DeepMiddle RequiredMiddle { get; init; }
+        }
+
+        public sealed record class DeepMiddle
+        {
+            public required DeepLeaf RequiredLeaf { get; init; }
+        }
+
+        public sealed record class DeepLeaf
+        {
+            public string? Value { get; init; }
+        }
+
+        public sealed class DeepRootValidator : AbstractValidator<DeepRoot>
+        {
+            public DeepRootValidator()
+            {
+                RuleFor(x => x.RequiredMiddle).NotNull();
+            }
+        }
+
+        public sealed class DeepMiddleValidator : AbstractValidator<DeepMiddle>
+        {
+            public DeepMiddleValidator()
+            {
+                RuleFor(x => x.RequiredLeaf).NotNull();
+            }
+        }
+
+        public sealed class DeepLeafValidator : AbstractValidator<DeepLeaf>
+        {
+            public DeepLeafValidator()
+            {
+                RuleFor(x => x.Value).NotEmpty();
+            }
+        }
+
+        public string GetDeep([FromQuery] DeepRoot filter) => filter.ToString();
+
+        // --- Validator-only requiredness fixtures (Issue #209, review item #6) ---
+        // 'Sub' is nullable and NOT a C# 'required' member — its requiredness comes solely
+        // from the FluentValidation NotNull() rule.
+        public sealed record class FvOnlyRoot
+        {
+            public FvOnlySub? Sub { get; init; }
+        }
+
+        public sealed record class FvOnlySub
+        {
+            public string? Value { get; init; }
+        }
+
+        public sealed class FvOnlyRootValidator : AbstractValidator<FvOnlyRoot>
+        {
+            public FvOnlyRootValidator()
+            {
+                RuleFor(x => x.Sub).NotNull();
+            }
+        }
+
+        public sealed class FvOnlySubValidator : AbstractValidator<FvOnlySub>
+        {
+            public FvOnlySubValidator()
+            {
+                RuleFor(x => x.Value).NotEmpty();
+            }
+        }
+
+        public string GetFvOnly([FromQuery] FvOnlyRoot filter) => filter.ToString();
 
 // OperationFilter integration tests require framework-specific OpenApi types.
 #if !OPENAPI_V2
@@ -138,6 +215,103 @@ namespace MicroElements.Swashbuckle.FluentValidation.Tests
                 because: "RequiredSubType is required (NotNull) and SubProperty is required (NotEmpty) — the whole path is required");
             operation.Parameters[0].Required.Should().BeFalse(
                 because: "OptionalSubType is optional, so the nested SubProperty must not become a required query parameter (Issue #209)");
+        }
+
+        /// <summary>
+        /// Issue #209 (review item #5): the dot-path walk must handle nesting deeper than two levels.
+        /// Only "RequiredMiddle.RequiredLeaf.Value" (all ancestors required) is a required parameter;
+        /// "OptionalMiddle.RequiredLeaf.Value" must stay optional because the first ancestor is optional.
+        /// </summary>
+        [Fact]
+        public void Three_Level_Nesting_Marks_Required_Only_When_All_Ancestors_Required()
+        {
+            var operation = RunOperationFilter(
+                new IValidator[] { new DeepRootValidator(), new DeepMiddleValidator(), new DeepLeafValidator() },
+                typeof(NestedFromQueryOptionalAncestorTest).GetMethod(nameof(GetDeep))!,
+                typeof(DeepLeaf),
+                nameof(DeepLeaf.Value),
+                "OptionalMiddle.RequiredLeaf.Value",
+                "RequiredMiddle.RequiredLeaf.Value");
+
+            operation.Parameters[0].Schema!.MinLength.Should().Be(1);
+            operation.Parameters[1].Schema!.MinLength.Should().Be(1);
+
+            operation.Parameters[1].Required.Should().BeTrue(
+                because: "every segment of RequiredMiddle.RequiredLeaf.Value is required");
+            operation.Parameters[0].Required.Should().BeFalse(
+                because: "OptionalMiddle is optional, so the deeply nested leaf must stay optional (Issue #209)");
+        }
+
+        /// <summary>
+        /// Issue #209 (review item #6): an ancestor that is required ONLY via a FluentValidation
+        /// NotNull() rule (the property is nullable and not a C# 'required' member) must still make
+        /// the nested leaf a required parameter.
+        /// </summary>
+        [Fact]
+        public void Ancestor_Required_Via_Validator_Only_Marks_Leaf_Required()
+        {
+            var operation = RunOperationFilter(
+                new IValidator[] { new FvOnlyRootValidator(), new FvOnlySubValidator() },
+                typeof(NestedFromQueryOptionalAncestorTest).GetMethod(nameof(GetFvOnly))!,
+                typeof(FvOnlySub),
+                nameof(FvOnlySub.Value),
+                "Sub.Value");
+
+            operation.Parameters[0].Schema!.MinLength.Should().Be(1);
+            operation.Parameters[0].Required.Should().BeTrue(
+                because: "Sub is required via NotNull() alone (no C# 'required'), so Sub.Value is required");
+        }
+
+        /// <summary>
+        /// Builds an operation with the given dot-path query parameters (all sharing the leaf container's
+        /// metadata, as Swashbuckle produces) and runs <see cref="FluentValidationOperationFilter"/>.
+        /// </summary>
+        private OpenApiOperation RunOperationFilter(
+            IValidator[] validators,
+            MethodInfo methodInfo,
+            Type leafContainerType,
+            string leafPropertyName,
+            params string[] parameterNames)
+        {
+            var schemaGeneratorOptions = new SchemaGeneratorOptions();
+            var schemaRepository = new SchemaRepository();
+            var schemaGenerator = SchemaGenerator(validators);
+
+            var schemaGenerationOptions = new SchemaGenerationOptions
+            {
+                NameResolver = new SystemTextJsonNameResolver(),
+                SchemaIdSelector = schemaGeneratorOptions.SchemaIdSelector,
+            };
+
+            var validatorRegistry = new ValidatorRegistry(
+                validators,
+                new OptionsWrapper<SchemaGenerationOptions>(schemaGenerationOptions));
+
+            var leafMetadata = new EmptyModelMetadataProvider().GetMetadataForProperty(leafContainerType, leafPropertyName);
+
+            var apiDescription = new ApiDescription();
+            var parameters = new List<OpenApiParameter>();
+            foreach (var name in parameterNames)
+            {
+                apiDescription.ParameterDescriptions.Add(new ApiParameterDescription
+                {
+                    Name = name,
+                    ModelMetadata = leafMetadata,
+                    Source = BindingSource.Query,
+                });
+                parameters.Add(new OpenApiParameter { Name = name, In = ParameterLocation.Query, Schema = new OpenApiSchema { Type = "string" } });
+            }
+
+            var operation = new OpenApiOperation { Parameters = parameters };
+
+            var context = new OperationFilterContext(apiDescription, schemaGenerator, schemaRepository, methodInfo);
+
+            new FluentValidationOperationFilter(
+                validatorRegistry: validatorRegistry,
+                schemaGenerationOptions: new OptionsWrapper<SchemaGenerationOptions>(schemaGenerationOptions))
+                .Apply(operation, context);
+
+            return operation;
         }
 #endif
     }

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>7.1.6</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionPrefix>7.1.7</VersionPrefix>
+    <VersionSuffix>beta.1</VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
Fixes #209. A required leaf property inside an **optional** nested type bound via `[FromQuery]` was wrongly marked as a required query parameter.

## Root cause
The 7.1.1 fix (#162, PR #194) made nested `[FromQuery]` validation match the **leaf** property name by stripping the dot-path prefix. But `FluentValidationOperationFilter` then set `required` based solely on the leaf type, **ignoring whether the ancestor segment of the dot-path is optional**.

Because two nested properties of the same leaf type share one schema/validator (e.g. `OptionalSubType.SubProperty` and `RequiredSubType.SubProperty` are both `FilterSubType`), a `NotEmpty()` on the leaf marked **both** flattened parameters as required:

```diff
   "name": "OptionalSubType.SubProperty",
   "in": "query",
+  "required": true,   // ← wrong: OptionalSubType is optional
   "name": "RequiredSubType.SubProperty",
   "in": "query",
+  "required": true,   // ← correct
```

History of the defect (two stages, same root):
- **≤ 7.1.0** — dot-path didn't match the leaf schema property → rules silently skipped → *neither* parameter required (too lax).
- **7.1.1+** — matching fixed → rules apply, but `required` over-propagates to optional ancestors (too strict, this issue).

## Fix
A flattened nested parameter is marked `required` only when **every** ancestor segment of the dot-path is required:
- the root `[FromQuery]`/`[AsParameters]` type is resolved from the action's `MethodInfo`;
- each ancestor segment's requiredness combines the native schema `required` (e.g. the C# `required` modifier) with the container validator's `NotNull`/`NotEmpty` rules;
- value constraints (e.g. `minLength`) still apply to an optional nested parameter when provided;
- if the root container type cannot be resolved, prior behavior is preserved (conservative fallback → no regression).

## Changes
- `FluentValidationOperationFilter.cs` — `IsParameterPathRequired` / `ResolveRootType` / `IsPropertyRequiredInType`; the `required` flag now gated on full-path requiredness
- `NestedFromQueryOptionalAncestorTest.cs` — regression test reproducing #209 (optional vs required nested object)
- `CHANGELOG.md` — 7.1.7 entry
- `version.props` — bump to `7.1.7-beta.1`

## Test plan
- [x] New test fails before the fix (`OptionalSubType.SubProperty` → `required: true`) and passes after
- [x] Differential run: existing tests pass **with and without** the fix — only the new #209 test changes state (no regression)
- [x] Full suite green: net8.0 95/95, net9.0 95/95, net10.0 80/80
- [x] No new StyleCop warnings in the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)