### PR TITLE
docs: document nested [FromQuery] validation behavior (Issue #211)

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,15 @@ The `Email`/`Name` constraints (and `required`) end up on the `CreateUserParams`
 
 MicroElements.Swashbuckle.FluentValidation updates swagger schema for operation parameters bounded to validatable models.
 
+### Nested `[FromQuery]` parameters
+
+When a `[FromQuery]` model has nested objects, ASP.NET Core flattens them into dot-path parameters (e.g. `RequiredSubType.SubProperty`). The validation rules for such a nested parameter are reflected in the OpenAPI document **only when they are actually enforced at runtime**:
+
+- The nested validator must be wired from the **root** validator via `SetValidator`/`ChildRules` (since [7.1.7](https://github.com/micro-elements/MicroElements.Swashbuckle.FluentValidation/issues/211)). FluentValidation never auto-validates a child object just because a validator for it is registered in DI — so an unwired nested validator no longer leaks `required`/length/pattern constraints onto the parameter.
+- A nested parameter is marked `required` only when **every** ancestor segment of the dot-path is required (see [#209](https://github.com/micro-elements/MicroElements.Swashbuckle.FluentValidation/issues/209)).
+
+> **Note:** if there is **no** validator registered for the root `[FromQuery]` type (only a leaf/child validator), the flattened nested parameter is left unconstrained — matching the default runtime, where no validation runs without a root validator. If you instead validate the child manually in the controller (e.g. `new SubValidator().Validate(filter.Child)`), those constraints cannot be detected statically and so are not reflected in the schema — register/wire a validator for the root type if you want them documented.
+
 ## Defining rules dynamically from database
 
 See BlogValidator in sample.


### PR DESCRIPTION
Adds a **Nested `[FromQuery]` parameters** subsection to the README, documenting the behavior introduced by the #209/#211 fixes:

- nested-parameter constraints are reflected only when the validator is wired from the **root** validator via `SetValidator`/`ChildRules` (#211);
- a nested parameter is `required` only when every dot-path ancestor is required (#209);
- the behavioral note raised by @cremor on #211: when **no** validator is registered for the root `[FromQuery]` type (or the child is validated manually in the controller body), the nested parameter is left unconstrained — those cases can't be detected statically.

Docs-only; no code changes. Follows up the already-shipped 7.1.7-beta.2 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)