### PR TITLE
Release 7.1.7 (stable)

### DIFF
--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>7.1.7</VersionPrefix>
-    <VersionSuffix>beta.3</VersionSuffix>
+    <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Promote **7.1.7** from `beta.3` to stable.

## Change
- `version.props`: clear `VersionSuffix` (`7.1.7-beta.3` → `7.1.7`)

## What ships in 7.1.7
- Nested `[FromQuery]` `required` over-propagation fix (Issue #209)
- Unwired nested `[FromQuery]` validator leaking into OpenAPI (Issue #211)
- Same fixes ported to native `Microsoft.AspNetCore.OpenApi` transformer + experimental DocumentFilter (Issue #213)

CHANGELOG already carries the `# Changes in 7.1.7` section.

Merging to `master` triggers CI which publishes `7.1.7` to NuGet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)