### PR TITLE
release: 7.1.8 — Microsoft.OpenApi security fix (#220) + IFormFile media types (#216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Changes in 7.1.8
+- Security (Issue #220): closed a transitive high-severity advisory in the published package. `Swashbuckle.AspNetCore.SwaggerGen` on the net10.0 target was bumped `10.0.0` → `10.2.1`, which resolves `Microsoft.OpenApi` to the patched `2.7.5` (was `2.3.0`). This clears **GHSA-v5pm-xwqc-g5wc / CVE-2026-49451** (CWE-674 uncontrolled recursion — a circular `$ref` schema could stack-overflow the OpenAPI reader). The net8.0/net9.0 targets use Swashbuckle 8.1.1 → Microsoft.OpenApi v1 and were never in the advisory range
+- Media type & file size validation for `IFormFile` uploads (Issue #216): stable rollup of everything in `7.1.8-beta.1` and `7.1.8-beta.2` below (new File-level rules `.FileContentType()`, `.MaxFileSize()`, `.MinFileSize()`, `.FileSizeBetween()`; Swashbuckle / NSwag / Microsoft.AspNetCore.OpenApi emit multipart `encoding.contentType` and description annotations)
+
 # Changes in 7.1.8-beta.2
 - All of `7.1.8-beta.1` below, plus: **Microsoft.AspNetCore.OpenApi** now also emits `encoding.contentType` for the file part (Issue #216) — the `FluentValidationOperationTransformer` writes `requestBody.content["multipart/form-data"].encoding.<part>.contentType` so UIs like Scalar/Swagger UI can show the accepted media types, not just the description. Works on net9.0 (inline form schema) and net10.0 (resolves the whole-body `$ref` component to find the part name)
 

--- a/src/MicroElements.Swashbuckle.FluentValidation/MicroElements.Swashbuckle.FluentValidation.csproj
+++ b/src/MicroElements.Swashbuckle.FluentValidation/MicroElements.Swashbuckle.FluentValidation.csproj
@@ -18,7 +18,8 @@
   <Import Project="..\common.props" />
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.0.0" />
+    <!-- 10.2.1 pulls patched Microsoft.OpenApi >= 2.7.5 (GHSA-v5pm-xwqc-g5wc / CVE-2026-49451). See issue #220. -->
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0'">

--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/MicroElements.Swashbuckle.FluentValidation.Tests.csproj
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/MicroElements.Swashbuckle.FluentValidation.Tests.csproj
@@ -20,9 +20,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.0.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.3.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.1" />
+    <!-- Patched: 2.3.0 is vulnerable to GHSA-v5pm-xwqc-g5wc / CVE-2026-49451. -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0'">

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>7.1.8</VersionPrefix>
-    <VersionSuffix>beta.2</VersionSuffix>
+    <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Overview

Cuts the **stable 7.1.8** release. It folds together two things:

1. **Security fix for Issue #220** (the reason for this release) — closes the transitive advisory **GHSA-v5pm-xwqc-g5wc / CVE-2026-49451**.
2. **Stable rollup of the #216 media-type / file-size work** that already shipped as `7.1.8-beta.1` / `7.1.8-beta.2` on `master`.

Fixes #220

## Security fix (#220)

The published package pulled a vulnerable `Microsoft.OpenApi 2.3.0` transitively via `Swashbuckle.AspNetCore.SwaggerGen 10.0.0` on the **net10.0** target:

```
MicroElements.Swashbuckle.FluentValidation
└── Swashbuckle.AspNetCore.SwaggerGen 10.0.0
    └── Swashbuckle.AspNetCore.Swagger 10.0.0
        └── Microsoft.OpenApi 2.3.0   ← vulnerable
```

- **Advisory:** GHSA-v5pm-xwqc-g5wc / CVE-2026-49451 — High (CVSS 7.5), CWE-674 Uncontrolled Recursion. A circular `$ref` schema can stack-overflow the OpenAPI reader (availability / process-termination; no RCE or data exposure).
- **Affected range:** `Microsoft.OpenApi >= 2.0.0-preview11, <= 2.7.4`. Patched in `2.7.5`.
- **Fix:** bump `Swashbuckle.AspNetCore.SwaggerGen` `10.0.0` → `10.2.1` (net10.0 target), which resolves `Microsoft.OpenApi` to **2.7.5**. Verified via `dotnet list package --include-transitive`.
- The **net8.0 / net9.0** targets use Swashbuckle `8.1.1` → `Microsoft.OpenApi` v1, which is outside the advisory range — left unchanged.
- Test project (net10.0): `Swashbuckle.AspNetCore(.Annotations)` → `10.2.1` and the direct `Microsoft.OpenApi` pin `2.3.0` → `2.7.5` (clears Dependabot alert #2).

## Release (version)

- `version.props`: dropped the `beta.2` suffix → stable `7.1.8`. `dotnet pack` confirmed it produces `...7.1.8.nupkg`.
- `CHANGELOG.md`: new `# Changes in 7.1.8` section rolling up the #216 work (beta.1/beta.2) plus the #220 security fix.

> ⚠️ Per this repo's release process, merging to `master` triggers the CI NuGet publish of **7.1.8**.

## Verification

- `dotnet test --framework net10.0` → **86 passed, 0 failed** (only pre-existing nullable warnings).
- `dotnet list package --include-transitive` (net10.0) → `Microsoft.OpenApi 2.7.5`.
- `dotnet pack -c Release` → `MicroElements.Swashbuckle.FluentValidation.7.1.8.nupkg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)